### PR TITLE
Read all files and fields, validate data frames afterwards

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     rlang,
     sf,
     lubridate,
-    tidyr
+    tidyr,
+    tools
 Suggests:
     testthat,
     knitr,

--- a/R/import.R
+++ b/R/import.R
@@ -1,4 +1,7 @@
 #' Create a gtfs object from all files within a directory
+#' @param directory_path path containing the unzipped txt feed files
+#' 
+#' @return a gtfs object
 create_gtfs_object <- function(directory_path, quiet = F) {
   if(tools::file_ext(directory_path) == "zip") {
     warning("found zip file instead of directory")

--- a/R/import.R
+++ b/R/import.R
@@ -1,26 +1,7 @@
 load_gtfs <- function(path) {
   
-  # TODO 1) download zip
-  
-  # TODO 2) extract zip
-  directory <- path
-  
-  # 3) list files in directory
-  files_list <- list_files(directory)
-  file_validation_result <- validate_file_list(files_list)
-  
-  # 4) list valid files
-  valid_file_paths <- valid_file_paths(files_list)
-  
-  # 5) read valid files to data frames and combine those to list
-  gtfs_list <- read_files(valid_file_paths)
-  
-  # 6) create gtfs_obj
-  gtfs_obj <- c(gtfs_list, files_validation_result = list(file_validation_result))
-  class(gtfs_obj) <- "gtfs"
-  
-  # 7) validate gtfs_obj
-  validate_gtfs(gtfs_obj)
+  file_list <- list_files(path)
+  gtfs_obj <- read_files(file_list)
   
   return(gtfs_obj)
 }

--- a/R/import.R
+++ b/R/import.R
@@ -11,6 +11,9 @@ create_gtfs_object <- function(directory_path, quiet = F) {
   # 1) list files in directory
   directory <- normalizePath(directory_path)
   files_list <- list.files(directory, full.names = TRUE)
+  if(length(files_list) == 0) {
+    stop(sprintf("No files found in directory '%s'", directory))
+  }
 
   # 2) read files to data frames and combine those to a list
   gtfs_obj <- read_files(files_list, quiet = quiet)
@@ -68,7 +71,7 @@ read_gtfs <- function(path, local = FALSE, quiet = FALSE) {
   gtfs_obj <- create_gtfs_object(path, quiet = quiet)
   
   # TODO move to "gtfs enrichment" function
-  gtfs_obj <- get_route_frequency(gtfs_obj) %>% gtfs_as_sf(quiet=quiet)
+  # gtfs_obj <- get_route_frequency(gtfs_obj) %>% gtfs_as_sf(quiet=quiet)
   
   return(gtfs_obj) 
 }

--- a/R/import.R
+++ b/R/import.R
@@ -356,17 +356,23 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
     # check if a file is empty. If so, return NULL.
     L <- suppressWarnings(length(scan(file_path, what = "", quiet = TRUE, sep = '\n')))
     if(L < 1) {
-      s <- sprintf("File '%s' is empty. Returning NULL.\n", basename(file_path))
+      s <- sprintf("   File '%s' is empty.", basename(file_path))
       message(s)
       return(NULL)
     }
 
     # if no meta data is found for a file type but file is not empty, read as is.
     if(is.null(meta)) {
-      s <- sprintf("File %s not recognized, reading file as csv", basename(file_path))
+      s <- sprintf("   File %s not recognized, trying to read file as csv", basename(file_path))
       message(s)
-      csv <- quote(readr::read_csv(file = file_path))
-      df <- suppressMessages(trigger_suppressWarnings(eval(csv), quiet))
+
+      tryCatch({
+        df <- suppressMessages(readr::read_csv(file = file_path))
+      }, error = function(error_condition) {
+        s <- sprintf("   File could not be read as csv.", basename(file_path))
+        message(s)
+        return(NULL)
+      })
       return(df)
     }
 

--- a/R/import.R
+++ b/R/import.R
@@ -264,29 +264,15 @@ list_files <- function(directory, quiet = FALSE) {
   }
 
   file_list <- list.files(directory, full.names = TRUE)
-  
-  named_file_list <- sapply(file_list,get_file_shortname)
-  
-  return(named_file_list)
+  return(file_list)
 }
 
-#' Function to read all files into dataframes
-#'
-#' @param file_path Character file path
-#' @param assign_envir Environment Object. Option of where to assign dataframes.
-#' @param quiet Boolean. Whether to output messages and files found in folder.
-#' @noRd
-#' @keywords internal
-
-read_files <- function(file_path_list, quiet = FALSE) {
-  # file_list <- sapply(all_files,get_file_shortname)
-  # files_validation_result <- validate_file_list(file_list)
-  # valid_files_meta <- files_validation_result %>%
-  #   dplyr::filter(spec != 'ext' & provided_status=="yes")
-  # 
-  # # browser()
-  # 
-  # valid_filenames <- names(file_list[file_list %in% valid_files_meta$file])
+read_files <- function(all_files, quiet = FALSE) {
+  file_list <- sapply(all_files,get_file_shortname)
+  file_validation_meta <- validate_file_list(file_list)
+  valid_files_meta <- file_validation_meta %>% 
+    dplyr::filter(spec != 'ext' & provided_status=="yes")
+  valid_filenames <- names(file_list[file_list %in% valid_files_meta$file])
   exec_env <- environment()
 
   # read valid files in environment
@@ -295,9 +281,10 @@ read_files <- function(file_path_list, quiet = FALSE) {
                                     assign_envir = exec_env, 
                                     quiet = quiet))
   
-  # combine all read objects of environment with "_df" to a list
   ls_envir <- ls(envir = exec_env)
+  
   df_list <- ls_envir[grepl(pattern = '_df', x = ls_envir)]
+  
   gtfs_list <- mget(df_list, envir = exec_env)
   
   if(!quiet) message('...done.\n\n')

--- a/R/import.R
+++ b/R/import.R
@@ -71,10 +71,9 @@ read_gtfs <- function(path, local = FALSE, quiet = FALSE) {
   gtfs_obj <- create_gtfs_object(path, quiet = quiet)
   
   # TODO move to "gtfs enrichment" function
-  gtfs_obj <- get_route_frequency() %>%
-    gtfs_as_sf(quiet=quiet)
+  gtfs_obj <- get_route_frequency(gtfs_obj) %>% gtfs_as_sf(quiet=quiet)
   
-  return(data_list) 
+  return(gtfs_obj) 
 }
 
 #' This function is deprecated. Please use read_gtfs

--- a/R/import.R
+++ b/R/import.R
@@ -1,7 +1,26 @@
 load_gtfs <- function(path) {
   
-  file_list <- list_files(path)
-  gtfs_obj <- read_files(file_list)
+  # TODO 1) download zip
+  
+  # TODO 2) extract zip
+  directory <- path
+  
+  # 3) list files in directory
+  files_list <- list_files(directory)
+  file_validation_result <- validate_file_list(files_list)
+  
+  # 4) list valid files
+  valid_file_paths <- valid_file_paths(files_list)
+  
+  # 5) read valid files to data frames and combine those to list
+  gtfs_list <- read_files(valid_file_paths)
+  
+  # 6) create gtfs_obj
+  gtfs_obj <- c(gtfs_list, files_validation_result = list(file_validation_result))
+  class(gtfs_obj) <- "gtfs"
+  
+  # 7) validate gtfs_obj
+  validate_gtfs(gtfs_obj)
   
   return(gtfs_obj)
 }
@@ -245,15 +264,29 @@ list_files <- function(directory, quiet = FALSE) {
   }
 
   file_list <- list.files(directory, full.names = TRUE)
-  return(file_list)
+  
+  named_file_list <- sapply(file_list,get_file_shortname)
+  
+  return(named_file_list)
 }
 
-read_files <- function(all_files, quiet = FALSE) {
-  file_list <- sapply(all_files,get_file_shortname)
-  file_validation_meta <- validate_file_list(file_list)
-  valid_files_meta <- file_validation_meta %>% 
-    dplyr::filter(spec != 'ext' & provided_status=="yes")
-  valid_filenames <- names(file_list[file_list %in% valid_files_meta$file])
+#' Function to read all files into dataframes
+#'
+#' @param file_path Character file path
+#' @param assign_envir Environment Object. Option of where to assign dataframes.
+#' @param quiet Boolean. Whether to output messages and files found in folder.
+#' @noRd
+#' @keywords internal
+
+read_files <- function(file_path_list, quiet = FALSE) {
+  # file_list <- sapply(all_files,get_file_shortname)
+  # files_validation_result <- validate_file_list(file_list)
+  # valid_files_meta <- files_validation_result %>%
+  #   dplyr::filter(spec != 'ext' & provided_status=="yes")
+  # 
+  # # browser()
+  # 
+  # valid_filenames <- names(file_list[file_list %in% valid_files_meta$file])
   exec_env <- environment()
 
   # read valid files in environment
@@ -262,10 +295,9 @@ read_files <- function(all_files, quiet = FALSE) {
                                     assign_envir = exec_env, 
                                     quiet = quiet))
   
+  # combine all read objects of environment with "_df" to a list
   ls_envir <- ls(envir = exec_env)
-  
   df_list <- ls_envir[grepl(pattern = '_df', x = ls_envir)]
-  
   gtfs_list <- mget(df_list, envir = exec_env)
   
   if(!quiet) message('...done.\n\n')

--- a/R/import.R
+++ b/R/import.R
@@ -1,3 +1,11 @@
+load_gtfs <- function(path) {
+  
+  file_list <- list_files(path)
+  gtfs_obj <- read_files(file_list)
+  
+  return(gtfs_obj)
+}
+
 #' Get and validate dataframes of General Transit Feed Specification (GTFS) data.
 #' 
 #' This function reads GTFS text files from a local or remote zip file. 
@@ -223,7 +231,7 @@ unzip_file <- function(zipfile,
 
 #' List all files in a directory
 #'
-#' @param ex_dir Character. Path to folder into which files were extracted.
+#' @param directory Character. Path to folder into which files were extracted.
 #' @param quiet Boolean. Whether to output messages and files found in folder.
 #' @keywords internal
 list_files <- function(directory, quiet = FALSE) {

--- a/R/import.R
+++ b/R/import.R
@@ -35,17 +35,13 @@ read_gtfs <- function(path, local = FALSE, quiet = FALSE) {
     data_list <- path %>%
       unzip_file(quiet=quiet) %>% 
          list_files(quiet=quiet) %>%
-            read_and_validate() %>%
-              get_route_frequency() %>%
-                gtfs_as_sf(quiet=quiet)
+            read_files()
   } else {
     data_list <- path %>%
       download_from_url(.) %>%
         unzip_file(quiet = quiet) %>%
           list_files(quiet = quiet) %>%
-            read_and_validate() %>%
-              get_route_frequency() %>%
-                gtfs_as_sf(quiet=quiet)
+            read_files()
   }
 
   return(data_list) 
@@ -182,7 +178,8 @@ has_bom <- function(path, encoding="UTF-8") {
 #' @param zipfile path to zipped file
 #' @param ex_dir path to unzip file to-default tempdir()
 #' @param quiet Boolean. Whether to output files found in folder.
-#'
+#' @importFrom tools %>% file_ext
+#' 
 #' @return file path to directory with gtfs .txt files
 #' @keywords internal
 #' 
@@ -191,7 +188,7 @@ unzip_file <- function(zipfile,
                        ex_dir=tempdir(), 
                        quiet = FALSE) {
   f <- zipfile
-
+  
   # check path
   if(try(path.expand(f), silent = TRUE) %>% assertthat::is.error()) {
     warn <- 'Invalid file path. NULL is returned.'
@@ -201,8 +198,12 @@ unzip_file <- function(zipfile,
 
   f <- normalizePath(f)
 
+  if(tools::file_ext(f) != "zip") {
+    if(!quiet) message('No zip file found, reading files from path.')
+    return(f)
+  }
+  
   # create extraction folder
-
   utils::unzip(f, exdir=ex_dir)
 
 
@@ -217,32 +218,31 @@ unzip_file <- function(zipfile,
   }
 
   return(ex_dir)
-
 }
 
 
-#' Read files with a "txt" suffix in a folder into objects in memory and delete files
+#' List all files in a directory
 #'
 #' @param ex_dir Character. Path to folder into which files were extracted.
 #' @param quiet Boolean. Whether to output messages and files found in folder.
 #' @keywords internal
-list_files <- function(ex_dir, quiet = FALSE) {
+list_files <- function(directory, quiet = FALSE) {
 
   # check path
-  check <- try(normalizePath(ex_dir), silent=TRUE)
+  check <- try(normalizePath(directory), silent=TRUE)
   if(assertthat::is.error(check)) {
     warn <- 'Invalid file path. NULL is returned.'
     if(!quiet) warning(warn)
     return(NULL)
   }
 
-  file_list <- list.files(ex_dir, full.names = TRUE)
+  file_list <- list.files(directory, full.names = TRUE)
   return(file_list)
 }
 
-read_and_validate <- function(all_files, quiet = FALSE) {
+read_files <- function(all_files, quiet = FALSE) {
   file_list <- sapply(all_files,get_file_shortname)
-  file_validation_meta <- validate_files(file_list)
+  file_validation_meta <- validate_file_list(file_list)
   valid_files_meta <- file_validation_meta %>% 
     dplyr::filter(spec != 'ext' & provided_status=="yes")
   valid_filenames <- names(file_list[file_list %in% valid_files_meta$file])
@@ -252,29 +252,16 @@ read_and_validate <- function(all_files, quiet = FALSE) {
          function(x) read_gtfs_file(x, 
                                     assign_envir = exec_env, 
                                     quiet = quiet))
-
-  ls_envir <- ls(envir = exec_env)
-
-  df_list <- ls_envir[grepl(pattern = '_df', x = ls_envir)]
-
-  gtfs_list <- mget(df_list, envir = exec_env)
-
-  if(!quiet) message('...done.\n\n')
-
-  # check if valid 'gtfs'
-  check <- validate_gtfs_structure(valid_files_meta, gtfs_list, return_gtfs_obj = FALSE, quiet = TRUE)
-  valid <- all(check$all_req_files, check$all_req_fields_in_req_files)
-
-  if(!quiet) message("Testing data structure...")
-  if(valid) {
-    class(gtfs_list) <- 'gtfs'
-    if(!quiet) message("...passed. Valid GTFS object.\n")
-  } else {
-    if(!quiet) message("...failed. Invalid data structure.\n")
-  }
-  gtfs_list$validation <- check 
-  return(gtfs_list)
   
+  ls_envir <- ls(envir = exec_env)
+  
+  df_list <- ls_envir[grepl(pattern = '_df', x = ls_envir)]
+  
+  gtfs_list <- mget(df_list, envir = exec_env)
+  
+  if(!quiet) message('...done.\n\n')
+  
+  return(gtfs_list)
 }
 
 #' Function to read all files into dataframes
@@ -291,7 +278,7 @@ read_gtfs_file <- function(file_path, assign_envir, quiet = FALSE) {
 
   if(!quiet) message(paste0('Reading ', df_name))
 
-  new_df <- parse_gtfs(prefix, file_path, quiet = quiet) 
+  new_df <- parse_gtfs_file(prefix, file_path, quiet = quiet) 
   # will have warning even though we fix problem
 
   assign(df_name, new_df, envir = assign_envir)
@@ -315,7 +302,7 @@ get_file_shortname <- function(file_path) {
   return(prefix)
 }
 
-#' Function to better read in GTFS txt files
+#' Parses one gtfs file
 #'
 #' @param prefix Character. gtfs file prefix (e.g. 'agency', 'stop_times', etc.)
 #' @param file_path Character. file path
@@ -324,7 +311,7 @@ get_file_shortname <- function(file_path) {
 #' @noRd
 #' @keywords internal
 
-parse_gtfs <- function(prefix, file_path, quiet = FALSE) {
+parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
 
   # only parse if file has any data, NULL o/w
   stopifnot(!is.na(file.size(file_path)))

--- a/R/import.R
+++ b/R/import.R
@@ -1,27 +1,27 @@
 load_gtfs <- function(path) {
-  
   # TODO 1) download zip
   
   # TODO 2) extract zip
-  directory <- path
-  
+  directory <- normalizePath(path)
+
   # 3) list files in directory
   files_list <- list_files(directory)
   files_validation_result <- validate_file_list(files_list)
   
   # 4) list valid files
-  valid_file_paths <- valid_file_paths(files_list)
+  valid_file_paths <- filepaths_to_read(directory, files_validation_result)
   
   # 5) read valid files to data frames and combine those to list
   gtfs_list <- read_files(valid_file_paths)
   
-  # 6) create gtfs_obj
-  gtfs_obj <- gtfs_list
-  attributes(gtfs_obj) <- append(attributes(gtfs_obj), list(files_validation_result = files_validation_result))
-  class(gtfs_obj) <- "gtfs"
+  # 6) add files_validation result to gtfs_obj attributes
+  attributes(gtfs_list) <- append(attributes(gtfs_list), list(files_validation_result = files_validation_result))
+  class(gtfs_list) <- "gtfs"
   
-  # 7) validate gtfs_obj
-  validate_gtfs(gtfs_obj)
+  # 7) validate and create gtfs_obj
+  gtfs_obj <- validate_gtfs_structure(gtfs_list)
+  
+  stopifnot(is_gtfs_obj(gtfs_obj))
   
   return(gtfs_obj)
 }
@@ -56,7 +56,6 @@ load_gtfs <- function(path) {
 #'         summarise(stop_count=n_distinct(stop_id)) %>%
 #'           arrange(desc(stop_count))
 #' }
-
 read_gtfs <- function(path, local = FALSE, quiet = FALSE) {
   if(local) {
     path <- normalizePath(path) 

--- a/R/import.R
+++ b/R/import.R
@@ -1,7 +1,26 @@
 load_gtfs <- function(path) {
   
-  file_list <- list_files(path)
-  gtfs_obj <- read_files(file_list)
+  # TODO 1) download zip
+  
+  # TODO 2) extract zip
+  directory <- path
+  
+  # 3) list files in directory
+  files_list <- list_files(directory)
+  file_validation_result <- validate_file_list(files_list)
+  
+  # 4) list valid files
+  valid_file_paths <- valid_file_paths(files_list)
+  
+  # 5) read valid files to data frames and combine those to list
+  gtfs_list <- read_files(valid_file_paths)
+  
+  # 6) create gtfs_obj
+  gtfs_obj <- c(gtfs_list, files_validation_result = list(file_validation_result))
+  class(gtfs_obj) <- "gtfs"
+  
+  # 7) validate gtfs_obj
+  validate_gtfs(gtfs_obj)
   
   return(gtfs_obj)
 }
@@ -245,26 +264,40 @@ list_files <- function(directory, quiet = FALSE) {
   }
 
   file_list <- list.files(directory, full.names = TRUE)
-  return(file_list)
+  
+  named_file_list <- sapply(file_list,get_file_shortname)
+  
+  return(named_file_list)
 }
 
-read_files <- function(all_files, quiet = FALSE) {
-  file_list <- sapply(all_files,get_file_shortname)
-  file_validation_meta <- validate_file_list(file_list)
-  valid_files_meta <- file_validation_meta %>% 
-    dplyr::filter(spec != 'ext' & provided_status=="yes")
-  valid_filenames <- names(file_list[file_list %in% valid_files_meta$file])
+#' Function to read all files into dataframes
+#'
+#' @param file_path Character file path
+#' @param assign_envir Environment Object. Option of where to assign dataframes.
+#' @param quiet Boolean. Whether to output messages and files found in folder.
+#' @noRd
+#' @keywords internal
+
+read_files <- function(file_path_list, quiet = FALSE) {
+  # file_list <- sapply(all_files,get_file_shortname)
+  # files_validation_result <- validate_file_list(file_list)
+  # valid_files_meta <- files_validation_result %>%
+  #   dplyr::filter(spec != 'ext' & provided_status=="yes")
+  # 
+  # # browser()
+  # 
+  # valid_filenames <- names(file_list[file_list %in% valid_files_meta$file])
   exec_env <- environment()
-  
-  lapply(valid_filenames, 
+
+  # read valid files in environment
+  lapply(file_path_list, 
          function(x) read_gtfs_file(x, 
                                     assign_envir = exec_env, 
                                     quiet = quiet))
   
+  # combine all read objects of environment with "_df" to a list
   ls_envir <- ls(envir = exec_env)
-  
   df_list <- ls_envir[grepl(pattern = '_df', x = ls_envir)]
-  
   gtfs_list <- mget(df_list, envir = exec_env)
   
   if(!quiet) message('...done.\n\n')

--- a/R/import.R
+++ b/R/import.R
@@ -7,7 +7,7 @@ load_gtfs <- function(path) {
   
   # 3) list files in directory
   files_list <- list_files(directory)
-  file_validation_result <- validate_file_list(files_list)
+  files_validation_result <- validate_file_list(files_list)
   
   # 4) list valid files
   valid_file_paths <- valid_file_paths(files_list)
@@ -16,7 +16,8 @@ load_gtfs <- function(path) {
   gtfs_list <- read_files(valid_file_paths)
   
   # 6) create gtfs_obj
-  gtfs_obj <- c(gtfs_list, files_validation_result = list(file_validation_result))
+  gtfs_obj <- gtfs_list
+  attributes(gtfs_obj) <- append(attributes(gtfs_obj), list(files_validation_result = files_validation_result))
   class(gtfs_obj) <- "gtfs"
   
   # 7) validate gtfs_obj
@@ -282,7 +283,7 @@ read_files <- function(file_path_list, quiet = FALSE) {
   # file_list <- sapply(all_files,get_file_shortname)
   # files_validation_result <- validate_file_list(file_list)
   # valid_files_meta <- files_validation_result %>%
-  #   dplyr::filter(spec != 'ext' & provided_status=="yes")
+  #   dplyr::filter(spec != 'ext' & provided_status)
   # 
   # # browser()
   # 

--- a/R/import.R
+++ b/R/import.R
@@ -414,11 +414,12 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
       }
 
     } else {
-      csv <- quote(readr::read_csv(file = file_path, col_types = coltypes, col_names = colnms, skip = 1L))
-      prob <- quote(readr::problems(readr::read_csv(file = file_path, col_types = coltypes, col_names = colnms, skip = 1L)))
-      df <- trigger_suppressWarnings(eval(csv), quiet)
-      probs <- trigger_suppressWarnings(eval(prob), quiet)
-
+      df <- readr::read_csv(file = file_path, 
+                            col_types = coltypes, 
+                            col_names = colnms, 
+                            skip = 1L)
+      probs <- readr::problems(df)
+      
       if(dim(probs)[1] > 0) attributes(df) <- append(attributes(df), list(problems = probs))
     }
 

--- a/R/import.R
+++ b/R/import.R
@@ -1,5 +1,9 @@
 #' Create a gtfs object from all files within a directory
 create_gtfs_object <- function(directory_path, quiet = F) {
+  if(tools::file_ext(directory_path) == "zip") {
+    warning("found zip file instead of directory")
+    return(NULL)
+  }
   # 1) list files in directory
   directory <- normalizePath(directory_path)
   files_list <- list_files(directory)
@@ -278,14 +282,6 @@ list_files <- function(directory, quiet = FALSE) {
 #' @keywords internal
 
 read_files <- function(file_path_list, quiet = FALSE) {
-  # file_list <- sapply(all_files,get_file_shortname)
-  # files_validation_result <- validate_file_list(file_list)
-  # valid_files_meta <- files_validation_result %>%
-  #   dplyr::filter(spec != 'ext' & provided_status)
-  # 
-  # # browser()
-  # 
-  # valid_filenames <- names(file_list[file_list %in% valid_files_meta$file])
   exec_env <- environment()
 
   # read valid files in environment
@@ -376,6 +372,8 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
       return(df)
     }
 
+    # browser()
+    
     ## read.csv supports UTF-8-BOM. use this to get field names.
     small_df <- suppressWarnings(utils::read.csv(file_path, nrows = 10, stringsAsFactors = FALSE)) # get a small df to find how many cols are needed
 
@@ -414,9 +412,8 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
 
     } else {
       df <- readr::read_csv(file = file_path, 
-                            col_types = coltypes, 
-                            col_names = colnms, 
-                            skip = 1L)
+                            col_types = coltypes
+        )
       probs <- readr::problems(df)
       
       if(dim(probs)[1] > 0) attributes(df) <- append(attributes(df), list(problems = probs))

--- a/R/spec.R
+++ b/R/spec.R
@@ -4,12 +4,44 @@
 
 get_gtfs_meta <- function() {
 
+  # required files ----------------------------------------------------------
+
   # agency
   assign("agency", list())
   agency$field <- c('agency_id', 'agency_name', 'agency_url', 'agency_timezone', 'agency_lang', 'agency_phone', 'agency_fare_url', 'agency_email')
   agency$spec <- c('opt', 'req', 'req', 'req', 'opt', 'opt', 'opt', 'opt')
   agency$coltype <- rep('c', 8)
-
+  
+  # stops
+  assign("stops", list())
+  stops$field <- c('stop_id', 'stop_code', 'platform_code', 'stop_name', 'stop_desc', 'stop_lat', 'stop_lon', 'zone_id', 'stop_url', 'location_type', 'parent_station', 'stop_timezone', 'wheelchair_boarding')
+  stops$spec <- c('req', 'opt', 'opt', 'req', 'opt', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt')
+  stops$coltype <- rep('c', length(stops$field))
+  stops$coltype[which(stops$field %in% c('stop_lat', 'stop_lon'))] <- 'd' # double
+  stops$coltype[which(stops$field %in% c('location_type', 'wheelchair_boarding'))] <- 'i' #integers
+  
+  # routes
+  assign("routes", list())
+  routes$field <- c('route_id', 'agency_id', 'route_short_name', 'route_long_name', 'route_desc', 'route_type', 'route_url', 'route_color', 'route_text_color', 'route_sort_order', 'min_headway_minutes')
+  routes$spec <- c('req', 'opt', 'req', 'req', 'opt', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
+  routes$coltype <- rep('c', length(routes$field))
+  routes$coltype[routes$field %in% c('route_type', 'route_sort_order', 'min_headway_minutes')] <- 'i'
+  
+  # trips
+  assign("trips", list())
+  trips$field <- c('route_id', 'service_id', 'trip_id', 'trip_headsign', 'trip_short_name', 'direction_id', 'block_id', 'shape_id', 'wheelchair_accessible', 'bikes_allowed')
+  trips$spec <- c('req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt')
+  trips$coltype <- rep('c', length(trips$field))
+  trips$coltype[trips$field %in% c('direction_id', 'wheelchair_accessible', 'bikes_allowed')] <- 'i'
+  
+  # stop_times
+  assign("stop_times", list())
+  stop_times$field <- c('trip_id', 'arrival_time', 'departure_time', 'stop_id', 'stop_sequence', 'stop_headsign', 'pickup_type', 'drop_off_type', 'shape_dist_traveled', 'timepoint')
+  stop_times$spec <- c('req', 'req', 'req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
+  stop_times$coltype <- rep('c', length(stop_times$field))
+  stop_times$coltype[stop_times$field %in% c('stop_sequence', 'pickup_type', 'drop_off_type', 'timepoint')] <- 'i'
+  stop_times$coltype[stop_times$field %in% c('shape_dist_traveled')] <- 'd'
+  
   # calendar
   assign("calendar", list())
   calendar$field <- c('service_id', 'service_name', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday', 'start_date', 'end_date')
@@ -18,11 +50,8 @@ get_gtfs_meta <- function() {
   calendar$coltype <- rep('i', length(calendar$field))
   calendar$coltype[calendar$field %in% c('service_id', 'service_name', 'start_date', 'end_date')] <- 'c'
 
-  # calendar_attributes
-  assign("calendar_attributes", list())
-  calendar_attributes$field <- c('service_id', 'service_description')
-  calendar_attributes$spec <- rep('req', times = 2)
-  calendar_attributes$coltype <- c('c', 'c')
+
+  # optional files ----------------------------------------------------------
 
   # calendar_dates
   assign("calendar_dates", list())
@@ -30,13 +59,7 @@ get_gtfs_meta <- function() {
   calendar_dates$spec <- c('req', 'req', 'req')
   calendar_dates$coltype <- rep('c', length(calendar_dates$field))
   calendar_dates$coltype[calendar_dates$field %in% c('exception_type')] <- 'i'
-
-   # directions
-  assign("directions", list())
-  directions$field <- c('route_id', 'direction_id', 'direction')
-  directions$spec <- rep('req', times = 3)
-  directions$coltype <- c('c', 'i', 'c')
-
+  
   # fare_attributes
   assign("fare_attributes", list())
   fare_attributes$field <- c('agency_id', 'fare_id', 'price', 'currency_type', 'payment_method', 'transfers', 'transfer_duration')
@@ -44,34 +67,22 @@ get_gtfs_meta <- function() {
   fare_attributes$coltype <- rep('c', length(fare_attributes$field))
   fare_attributes$coltype[fare_attributes$field %in% c('payment_method', 'transfers')] <- 'i'
   fare_attributes$coltype[fare_attributes$field %in% c('transfer_duration')] <- 'd'
-
-  # fare_rider_categories
-  assign("fare_rider_categories", list())
-  fare_rider_categories$field <- c('fare_id', 'rider_category_id', 'price')
-  fare_rider_categories$spec <- c('req', 'req', 'req')
-  fare_rider_categories$coltype <- c('c', 'c', 'd')
-
+  
   # fare_rules
   assign("fare_rules", list())
   fare_rules$field <- c('fare_id', 'route_id', 'origin_id', 'destination_id', 'contains_id')
   fare_rules$spec <- c('req', 'opt', 'opt', 'opt', 'opt')
   fare_rules$coltype <- rep('c', length(fare_rules$field))
   fare_rules$coltype[fare_rules$field %in% c('direction_id', 'wheelchair_accessible', 'bikes_allowed')] <- 'i'
-
-  # farezone_attributes
-  assign("farezone_attributes", list())
-  farezone_attributes$field <- c('zone_id', 'zone_name')
-  farezone_attributes$spec <- c('req', 'req')
-  farezone_attributes$coltype <- rep('c', length(farezone_attributes$field))
-
-  # feed_info
-  assign("feed_info", list())
-  feed_info$field <- c('feed_id', 'feed_publisher_name', 'feed_publisher_url', 'feed_lang', 'feed_version', 'feed_license', 'feed_contact_email', 'feed_contact_url', 'feed_start_date', 'feed_end_date')
-  feed_info$spec <- rep('opt', times = length(feed_info$field))
-  reqs <- c(2:4)
-  feed_info$spec[reqs] <- 'req'
-  feed_info$coltype <- rep('c', length(feed_info$field))
-
+  
+  # shapes
+  assign("shapes", list())
+  shapes$field <- c('shape_id', 'shape_pt_lat', 'shape_pt_lon', 'shape_pt_sequence', 'shape_dist_traveled')
+  shapes$spec <- c('req', 'req', 'req', 'req', 'opt')
+  shapes$coltype <- rep('d', length(shapes$field))
+  shapes$coltype[shapes$field %in% c('shape_id')] <- 'c'
+  shapes$coltype[shapes$field %in% c('shape_pt_sequence')] <- 'i'
+  
   # frequencies
   assign("frequencies", list())
   frequencies$field <- c('trip_id', 'start_time', 'end_time', 'headway_secs', 'exact_times')
@@ -79,6 +90,48 @@ get_gtfs_meta <- function() {
   frequencies$coltype <- rep('c', length(frequencies$field))
   frequencies$coltype[frequencies$field %in% c('headway_secs')] <- 'd'
   frequencies$coltype[frequencies$field %in% c('exact_times')] <- 'i'
+  
+  # transfers
+  assign("transfers", list())
+  transfers$field <- c('from_stop_id', 'to_stop_id', 'transfer_type', 'min_transfer_time')
+  transfers$spec <- c('req', 'req', 'req', 'opt')
+  transfers$coltype <- rep('c', length(transfers$field))
+  transfers$coltype[transfers$field %in% c('exception_type')] <- 'i'
+  
+  # feed_info
+  assign("feed_info", list())
+  feed_info$field <- c('feed_id', 'feed_publisher_name', 'feed_publisher_url', 'feed_lang', 'feed_version', 'feed_license', 'feed_contact_email', 'feed_contact_url', 'feed_start_date', 'feed_end_date')
+  feed_info$spec <- rep('opt', times = length(feed_info$field))
+  reqs <- c(2:4)
+  feed_info$spec[reqs] <- 'req'
+  feed_info$coltype <- rep('c', length(feed_info$field))
+  
+
+  # extra optional files ----------------------------------------------------
+
+  # calendar_attributes
+  assign("calendar_attributes", list())
+  calendar_attributes$field <- c('service_id', 'service_description')
+  calendar_attributes$spec <- rep('req', times = 2)
+  calendar_attributes$coltype <- c('c', 'c')
+
+ # directions
+  assign("directions", list())
+  directions$field <- c('route_id', 'direction_id', 'direction')
+  directions$spec <- rep('req', times = 3)
+  directions$coltype <- c('c', 'i', 'c')
+
+  # fare_rider_categories
+  assign("fare_rider_categories", list())
+  fare_rider_categories$field <- c('fare_id', 'rider_category_id', 'price')
+  fare_rider_categories$spec <- c('req', 'req', 'req')
+  fare_rider_categories$coltype <- c('c', 'c', 'd')
+
+  # farezone_attributes
+  assign("farezone_attributes", list())
+  farezone_attributes$field <- c('zone_id', 'zone_name')
+  farezone_attributes$spec <- c('req', 'req')
+  farezone_attributes$coltype <- rep('c', length(farezone_attributes$field))
 
   # rider_categories
   assign("rider_categories", list())
@@ -93,42 +146,11 @@ get_gtfs_meta <- function() {
   route_directions$coltype <- rep('c', length(route_directions$field))
   route_directions$coltype[route_directions$field %in% c("direction_id")] <- 'i'
 
-  # routes
-  assign("routes", list())
-  routes$field <- c('route_id', 'agency_id', 'route_short_name', 'route_long_name', 'route_desc', 'route_type', 'route_url', 'route_color', 'route_text_color', 'route_sort_order', 'min_headway_minutes')
-  routes$spec <- c('req', 'opt', 'req', 'req', 'opt', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
-  routes$coltype <- rep('c', length(routes$field))
-  routes$coltype[routes$field %in% c('route_type', 'route_sort_order', 'min_headway_minutes')] <- 'i'
-
-  # shapes
-  assign("shapes", list())
-  shapes$field <- c('shape_id', 'shape_pt_lat', 'shape_pt_lon', 'shape_pt_sequence', 'shape_dist_traveled')
-  shapes$spec <- c('req', 'req', 'req', 'req', 'opt')
-  shapes$coltype <- rep('d', length(shapes$field))
-  shapes$coltype[shapes$field %in% c('shape_id')] <- 'c'
-  shapes$coltype[shapes$field %in% c('shape_pt_sequence')] <- 'i'
-
   # stop_attributes
   assign("stop_attributes", list())
   stop_attributes$field <- c('stop_id', 'stop_city')
   stop_attributes$spec <- c('req', 'req')
   stop_attributes$coltype <- c('c', 'c')
-
-  # stop_times
-  assign("stop_times", list())
-  stop_times$field <- c('trip_id', 'arrival_time', 'departure_time', 'stop_id', 'stop_sequence', 'stop_headsign', 'pickup_type', 'drop_off_type', 'shape_dist_traveled', 'timepoint')
-  stop_times$spec <- c('req', 'req', 'req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
-  stop_times$coltype <- rep('c', length(stop_times$field))
-  stop_times$coltype[stop_times$field %in% c('stop_sequence', 'pickup_type', 'drop_off_type', 'timepoint')] <- 'i'
-  stop_times$coltype[stop_times$field %in% c('shape_dist_traveled')] <- 'd'
-
-  # stops
-  assign("stops", list())
-  stops$field <- c('stop_id', 'stop_code', 'platform_code', 'stop_name', 'stop_desc', 'stop_lat', 'stop_lon', 'zone_id', 'stop_url', 'location_type', 'parent_station', 'stop_timezone', 'wheelchair_boarding')
-  stops$spec <- c('req', 'opt', 'opt', 'req', 'opt', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt')
-  stops$coltype <- rep('c', length(stops$field))
-  stops$coltype[which(stops$field %in% c('stop_lat', 'stop_lon'))] <- 'd' # double
-  stops$coltype[which(stops$field %in% c('location_type', 'wheelchair_boarding'))] <- 'i' #integers
 
   # timetable_stop_order
   assign("timetable_stop_order", list())
@@ -145,20 +167,6 @@ get_gtfs_meta <- function() {
   timetables$spec[timetables$field %in% c("route_label", "service_notes", "direction_label", "orientation")] <- 'opt'
   timetables$coltype <- rep('c', length(timetables$field))
   timetables$coltype[timetables$field %in% c("direction_id", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")] <- 'i'
-
-  # transfers
-  assign("transfers", list())
-  transfers$field <- c('from_stop_id', 'to_stop_id', 'transfer_type', 'min_transfer_time')
-  transfers$spec <- c('req', 'req', 'req', 'opt')
-  transfers$coltype <- rep('c', length(transfers$field))
-  transfers$coltype[transfers$field %in% c('exception_type')] <- 'i'
-
-  # trips
-  assign("trips", list())
-  trips$field <- c('route_id', 'service_id', 'trip_id', 'trip_headsign', 'trip_short_name', 'direction_id', 'block_id', 'shape_id', 'wheelchair_accessible', 'bikes_allowed')
-  trips$spec <- c('req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt')
-  trips$coltype <- rep('c', length(trips$field))
-  trips$coltype[trips$field %in% c('direction_id', 'wheelchair_accessible', 'bikes_allowed')] <- 'i'
 
   environment()
 

--- a/R/spec.R
+++ b/R/spec.R
@@ -9,166 +9,196 @@ get_gtfs_meta <- function() {
   # agency
   assign("agency", list())
   agency$field <- c('agency_id', 'agency_name', 'agency_url', 'agency_timezone', 'agency_lang', 'agency_phone', 'agency_fare_url', 'agency_email')
-  agency$spec <- c('opt', 'req', 'req', 'req', 'opt', 'opt', 'opt', 'opt')
+  agency$field_spec <- c('opt', 'req', 'req', 'req', 'opt', 'opt', 'opt', 'opt')
+  names(agency$field_spec) <- agency$field
   agency$coltype <- rep('c', 8)
+  agency$file_spec <- 'req'
   
   # stops
   assign("stops", list())
   stops$field <- c('stop_id', 'stop_code', 'platform_code', 'stop_name', 'stop_desc', 'stop_lat', 'stop_lon', 'zone_id', 'stop_url', 'location_type', 'parent_station', 'stop_timezone', 'wheelchair_boarding')
-  stops$spec <- c('req', 'opt', 'opt', 'req', 'opt', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt')
+  stops$field_spec <- c('req', 'opt', 'opt', 'req', 'opt', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt')
+  names(stops$field_spec) <- stops$field
   stops$coltype <- rep('c', length(stops$field))
   stops$coltype[which(stops$field %in% c('stop_lat', 'stop_lon'))] <- 'd' # double
   stops$coltype[which(stops$field %in% c('location_type', 'wheelchair_boarding'))] <- 'i' #integers
+  stops$file_spec <- 'req'
   
   # routes
   assign("routes", list())
   routes$field <- c('route_id', 'agency_id', 'route_short_name', 'route_long_name', 'route_desc', 'route_type', 'route_url', 'route_color', 'route_text_color', 'route_sort_order', 'min_headway_minutes')
-  routes$spec <- c('req', 'opt', 'req', 'req', 'opt', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
+  routes$field_spec <- c('req', 'opt', 'req', 'req', 'opt', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
+  names(routes$field_spec) <- routes$field
   routes$coltype <- rep('c', length(routes$field))
   routes$coltype[routes$field %in% c('route_type', 'route_sort_order', 'min_headway_minutes')] <- 'i'
+  routes$file_spec <- 'req'
   
   # trips
   assign("trips", list())
   trips$field <- c('route_id', 'service_id', 'trip_id', 'trip_headsign', 'trip_short_name', 'direction_id', 'block_id', 'shape_id', 'wheelchair_accessible', 'bikes_allowed')
-  trips$spec <- c('req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt')
+  trips$field_spec <- c('req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt')
+  names(trips$field_spec) <- trips$field
   trips$coltype <- rep('c', length(trips$field))
   trips$coltype[trips$field %in% c('direction_id', 'wheelchair_accessible', 'bikes_allowed')] <- 'i'
+  trips$file_spec <- 'req'
   
   # stop_times
   assign("stop_times", list())
   stop_times$field <- c('trip_id', 'arrival_time', 'departure_time', 'stop_id', 'stop_sequence', 'stop_headsign', 'pickup_type', 'drop_off_type', 'shape_dist_traveled', 'timepoint')
-  stop_times$spec <- c('req', 'req', 'req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
+  stop_times$field_spec <- c('req', 'req', 'req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
+  names(stop_times$field_spec) <- stop_times$field
   stop_times$coltype <- rep('c', length(stop_times$field))
   stop_times$coltype[stop_times$field %in% c('stop_sequence', 'pickup_type', 'drop_off_type', 'timepoint')] <- 'i'
   stop_times$coltype[stop_times$field %in% c('shape_dist_traveled')] <- 'd'
+  stop_times$file_spec <- 'req'
   
   # calendar
   assign("calendar", list())
   calendar$field <- c('service_id', 'service_name', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday', 'start_date', 'end_date')
-  calendar$spec <- rep('req', times = length(calendar$field))
-  calendar$spec[2] <- 'opt'
+  calendar$field_spec <- rep('req', times = length(calendar$field))
+  calendar$field_spec[2] <- 'opt'
+  names(calendar$field_spec) <- calendar$field
   calendar$coltype <- rep('i', length(calendar$field))
   calendar$coltype[calendar$field %in% c('service_id', 'service_name', 'start_date', 'end_date')] <- 'c'
-
+  calendar$file_spec <- 'req'
 
   # optional files ----------------------------------------------------------
 
   # calendar_dates
   assign("calendar_dates", list())
   calendar_dates$field <- c('service_id', 'date', 'exception_type')
-  calendar_dates$spec <- c('req', 'req', 'req')
+  calendar_dates$field_spec <- c('req', 'req', 'req')
+  names(calendar_dates$field_spec) <- calendar_dates$field
   calendar_dates$coltype <- rep('c', length(calendar_dates$field))
   calendar_dates$coltype[calendar_dates$field %in% c('exception_type')] <- 'i'
+  calendar_dates$file_spec <- 'opt'
   
   # fare_attributes
   assign("fare_attributes", list())
   fare_attributes$field <- c('agency_id', 'fare_id', 'price', 'currency_type', 'payment_method', 'transfers', 'transfer_duration')
-  fare_attributes$spec <- c('opt', 'req', 'req', 'req', 'req', 'req', 'opt')
+  fare_attributes$field_spec <- c('opt', 'req', 'req', 'req', 'req', 'req', 'opt')
+  names(fare_attributes$field_spec) <- fare_attributes$field
   fare_attributes$coltype <- rep('c', length(fare_attributes$field))
   fare_attributes$coltype[fare_attributes$field %in% c('payment_method', 'transfers')] <- 'i'
   fare_attributes$coltype[fare_attributes$field %in% c('transfer_duration')] <- 'd'
+  fare_attributes$file_spec <- 'opt'
   
   # fare_rules
   assign("fare_rules", list())
   fare_rules$field <- c('fare_id', 'route_id', 'origin_id', 'destination_id', 'contains_id')
-  fare_rules$spec <- c('req', 'opt', 'opt', 'opt', 'opt')
+  fare_rules$field_spec <- c('req', 'opt', 'opt', 'opt', 'opt')
+  names(fare_rules$field_spec) <- fare_rules$field
   fare_rules$coltype <- rep('c', length(fare_rules$field))
   fare_rules$coltype[fare_rules$field %in% c('direction_id', 'wheelchair_accessible', 'bikes_allowed')] <- 'i'
-  
+  fare_rules$file_spec <- 'opt'
+    
   # shapes
   assign("shapes", list())
   shapes$field <- c('shape_id', 'shape_pt_lat', 'shape_pt_lon', 'shape_pt_sequence', 'shape_dist_traveled')
-  shapes$spec <- c('req', 'req', 'req', 'req', 'opt')
+  shapes$field_spec <- c('req', 'req', 'req', 'req', 'opt')
+  names(shapes$field_spec) <- shapes$field
   shapes$coltype <- rep('d', length(shapes$field))
   shapes$coltype[shapes$field %in% c('shape_id')] <- 'c'
   shapes$coltype[shapes$field %in% c('shape_pt_sequence')] <- 'i'
+  shapes$file_spec <- 'opt'
   
   # frequencies
   assign("frequencies", list())
   frequencies$field <- c('trip_id', 'start_time', 'end_time', 'headway_secs', 'exact_times')
-  frequencies$spec <- c('req', 'req', 'req', 'req', 'opt')
+  frequencies$field_spec <- c('req', 'req', 'req', 'req', 'opt')
+  names(frequencies$field_spec) <- frequencies$field
   frequencies$coltype <- rep('c', length(frequencies$field))
   frequencies$coltype[frequencies$field %in% c('headway_secs')] <- 'd'
   frequencies$coltype[frequencies$field %in% c('exact_times')] <- 'i'
+  frequencies$file_spec <- 'opt'
   
   # transfers
   assign("transfers", list())
   transfers$field <- c('from_stop_id', 'to_stop_id', 'transfer_type', 'min_transfer_time')
-  transfers$spec <- c('req', 'req', 'req', 'opt')
+  transfers$field_spec <- c('req', 'req', 'req', 'opt')
+  names(transfers$field_spec) <- transfers$field
   transfers$coltype <- rep('c', length(transfers$field))
   transfers$coltype[transfers$field %in% c('exception_type')] <- 'i'
+  transfers$file_spec <- 'opt'
   
   # feed_info
   assign("feed_info", list())
   feed_info$field <- c('feed_id', 'feed_publisher_name', 'feed_publisher_url', 'feed_lang', 'feed_version', 'feed_license', 'feed_contact_email', 'feed_contact_url', 'feed_start_date', 'feed_end_date')
-  feed_info$spec <- rep('opt', times = length(feed_info$field))
-  reqs <- c(2:4)
-  feed_info$spec[reqs] <- 'req'
+  feed_info$field_spec <- rep('opt', times = length(feed_info$field))
+  feed_info$field_spec[c(2:4)] <- 'req'
+  names(feed_info$field_spec) <- feed_info$field
   feed_info$coltype <- rep('c', length(feed_info$field))
+  feed_info$file_spec <- 'opt'
   
+  meta <- list(agency, stops, routes, trips, stop_times, calendar, calendar_dates, fare_attributes, fare_rules, shapes, frequencies, transfers, feed_info)
+  attributes(meta) <- list(
+    names = c("agency", "stops", "routes", "trips", "stop_times", "calendar", "calendar_dates", "fare_attributes", "fare_rules", "shapes", "frequencies", "transfers", "feed_info"),
+    file_spec = c('req', 'req', 'req', 'req','req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt', 'opt'))
+  
+  return(meta)
+}
 
-  # extra optional files ----------------------------------------------------
-
+get_gtfs_plus_meta <- function() {
+  
   # calendar_attributes
   assign("calendar_attributes", list())
   calendar_attributes$field <- c('service_id', 'service_description')
-  calendar_attributes$spec <- rep('req', times = 2)
+  calendar_attributes$field_spec <- rep('req', times = 2)
   calendar_attributes$coltype <- c('c', 'c')
-
- # directions
+  
+  # directions
   assign("directions", list())
   directions$field <- c('route_id', 'direction_id', 'direction')
-  directions$spec <- rep('req', times = 3)
+  directions$field_spec <- rep('req', times = 3)
   directions$coltype <- c('c', 'i', 'c')
-
+  
   # fare_rider_categories
   assign("fare_rider_categories", list())
   fare_rider_categories$field <- c('fare_id', 'rider_category_id', 'price')
-  fare_rider_categories$spec <- c('req', 'req', 'req')
+  fare_rider_categories$field_spec <- c('req', 'req', 'req')
   fare_rider_categories$coltype <- c('c', 'c', 'd')
-
+  
   # farezone_attributes
   assign("farezone_attributes", list())
   farezone_attributes$field <- c('zone_id', 'zone_name')
-  farezone_attributes$spec <- c('req', 'req')
+  farezone_attributes$field_spec <- c('req', 'req')
   farezone_attributes$coltype <- rep('c', length(farezone_attributes$field))
-
+  
   # rider_categories
   assign("rider_categories", list())
   rider_categories$field <- c('rider_category_id', 'rider_category_description')
-  rider_categories$spec <- c('req', 'req')
+  rider_categories$field_spec <- c('req', 'req')
   rider_categories$coltype <- rep('c', length(rider_categories$field))
-
+  
   # route_directions
   assign("route_directions", list())
   route_directions$field <- c("route_id", "direction_id", "direction_name")
-  route_directions$spec <- rep('req', length(route_directions$field))
+  route_directions$field_spec <- rep('req', length(route_directions$field))
   route_directions$coltype <- rep('c', length(route_directions$field))
   route_directions$coltype[route_directions$field %in% c("direction_id")] <- 'i'
-
+  
   # stop_attributes
   assign("stop_attributes", list())
   stop_attributes$field <- c('stop_id', 'stop_city')
-  stop_attributes$spec <- c('req', 'req')
+  stop_attributes$field_spec <- c('req', 'req')
   stop_attributes$coltype <- c('c', 'c')
-
+  
   # timetable_stop_order
   assign("timetable_stop_order", list())
   timetable_stop_order$field <- c("timetable_id", "stop_id", "stop_sequence", "stop_name", "connected_routes")
-  timetable_stop_order$spec <- rep('req', length(timetable_stop_order$field))
-  timetable_stop_order$spec[timetable_stop_order$field %in% c("stop_name", "connected_routes")] <- 'opt'
+  timetable_stop_order$field_spec <- rep('req', length(timetable_stop_order$field))
+  timetable_stop_order$field_spec[timetable_stop_order$field %in% c("stop_name", "connected_routes")] <- 'opt'
   timetable_stop_order$coltype <- rep('c', length(timetable_stop_order$field))
   timetable_stop_order$coltype[timetable_stop_order$field %in% c("stop_sequence")] <- 'i'
-
+  
   # timetables
   assign("timetables", list())
   timetables$field <- c("timetable_id", "route_id", "direction_id", "start_date", "end_date", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday", "route_label", "service_notes", "direction_label", "orientation")
-  timetables$spec <- rep('req', length(timetables$field))
-  timetables$spec[timetables$field %in% c("route_label", "service_notes", "direction_label", "orientation")] <- 'opt'
+  timetables$field_spec <- rep('req', length(timetables$field))
+  timetables$field_spec[timetables$field %in% c("route_label", "service_notes", "direction_label", "orientation")] <- 'opt'
   timetables$coltype <- rep('c', length(timetables$field))
   timetables$coltype[timetables$field %in% c("direction_id", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")] <- 'i'
-
+  
   environment()
-
 }
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -1,7 +1,40 @@
+#' Validation table that defines for every data frame within gtfs_obj
+#' whether the file is required ('req'), optional ('opt') or an extra 
+#' file ('ext'). The same is applied for each field. The validation_status
+#' column points problems with files/fiels. 
 validate_gtfs <- function(gtfs_obj) {
 
+  validation_result <- validate_gtfs_structure(gtfs_obj)
+  
+  # check existing files and fields
+  validation_result$validation_status <- 'ok'
+  validation_result$validation_details <- NA
+  
+  validation_result <- validation_result %>% 
+    dplyr::mutate(validation_details = NA) %>% # default to NA
+    dplyr::mutate(validation_details = replace(validation_details, !file_provided_status & file_spec == 'req', 'missing_req_file')) %>% # req file missing
+    dplyr::mutate(validation_details = replace(validation_details, !file_provided_status & file_spec == 'opt', 'missing_opt_file')) %>% # optional file missing
+    dplyr::mutate(validation_details = replace(validation_details, file_provided_status & field_spec == 'req' & !field_provided_status, 'missing_req_field')) %>%
+    dplyr::mutate(validation_details = replace(validation_details, file_provided_status & field_spec == 'opt' & !field_provided_status, 'missing_opt_field'))
+
+  validation_result <- validation_result %>% 
+    dplyr::mutate(validation_status = replace(validation_status, validation_details == 'missing_req_file', 'problem')) %>% 
+    dplyr::mutate(validation_status = replace(validation_status, validation_details == 'missing_req_field', 'problem')) %>% 
+    dplyr::mutate(validation_status = replace(validation_status, !is.na(validation_details), 'info'))
+  
+  # assign validation result to gtfs_obj
+  attributes(gtfs_obj) <- append(attributes(gtfs_obj), list(validation_result = validation_result))
+  
+  return(gtfs_obj)
+}
+
+#' Create validation table for a gtfs_obj. It provides an overview of the structure of all files that were imported.
+#'
+#' @param gtfs_obj A GTFS list object with components agency_df, etc.
+validate_gtfs_structure <- function(gtfs_obj) {
+
   meta <- get_gtfs_meta()
-  validation_result <- tibble::tibble()
+  structure <- tibble::tibble()
   
   # check files => data frames
   for(dfname in names(gtfs_obj)) {
@@ -34,108 +67,22 @@ validate_gtfs <- function(gtfs_obj) {
       }
       df_validation <- tibble::tibble(file, file_spec, file_provided_status, field = cnames, field_spec = 'ext', field_provided_status = T)
     }
-    validation_result <- rbind(validation_result, df_validation)
+    structure <- rbind(structure, df_validation)
   }
   
   # checks for the missing calendar.txt exception, see https://developers.google.com/transit/gtfs/reference/#calendar_datestxt
   # if the exception is TRUE, then calendar has its file spec set to 'extra' and calendar_dates is required
-  calendar_exists <- validation_result %>% filter(file == "calendar") %>% pull(file_provided_status) %>% all()
+  calendar_exists <- structure %>% filter(file == "calendar") %>% pull(file_provided_status) %>% all()
   if(!calendar_exists) {
-    validation_result <- validation_result %>% 
+    structure <- structure %>% 
       dplyr::mutate(file_spec = replace(file_spec, file == 'calendar', 'ext')) %>% 
       dplyr::mutate(file_spec = replace(file_spec, file == 'calendar_dates', 'req'))
   }
   
-  
-  # check existign files and fields
-  validation_result$validation_status <- 'ok'
-  validation_result$validation_details <- NA
-  
-  validation_result <- validation_result %>% 
-    dplyr::mutate(validation_details = NA) %>% # default to NA
-    dplyr::mutate(validation_details = replace(validation_details, !file_provided_status & file_spec == 'opt', 'missing_opt_file')) %>% # optional file missing
-    dplyr::mutate(validation_details = replace(validation_details, !file_provided_status & file_spec == 'req', 'missing_req_file')) %>% # req file missing
-    dplyr::mutate(validation_details = replace(validation_details, file_provided_status & field_spec == 'req' & !field_provided_status, 'missing_req_field')) %>%
-    dplyr::mutate(validation_details = replace(validation_details, file_provided_status & field_spec == 'opt' & !field_provided_status, 'missing_opt_field'))
-
-  validation_result <- validation_result %>% 
-    dplyr::mutate(validation_status = replace(validation_status, validation_details == 'missing_req_file', 'problem')) %>% 
-    dplyr::mutate(validation_status = replace(validation_status, validation_details == 'missing_req_field', 'problem')) %>% 
-    dplyr::mutate(validation_status = replace(validation_status, !is.na(validation_details), 'info'))
-  
-  # assign validation result to gtfs_obj
-  attributes(gtfs_obj) <- append(attributes(gtfs_obj), list(validation_result = validation_result))
-  
-  return(gtfs_obj)
+  return(structure)
 }
 
-#' Create validation list for a gtfs_obj. It provides an overview of the structure of all files that were imported.
-#'
-#' @param gtfs_obj A GTFS list object with components agency_df, etc.
-#' @param return_gtfs_obj Boolean. If TRUE, returns gtfs_obj list with a 'validate' attribute appended (TRUE by default),
-#'                    if FALSE, returns validate list only
-#' @param quiet Boolean. Option to suppress any messages, prints, etc
-#'
-#' @return A gtfs_obj list object with attribute 'validate' or just a list containing validation data
-#'
-#' @keywords internal
-
-validate_gtfs_structure <- function(gtfs_obj, return_gtfs_obj = TRUE, quiet = FALSE) {
-  if (length(gtfs_obj) == 0) {
-    warning('Empty gtfs_obj')
-    return(NULL)
-  }
-
-  files_validation_result <- attributes(gtfs_obj)$files_validation_result
-  
-  all_val_df <- validate_vars(gtfs_obj) %>%
-    calendar_exception_fix()
-
-  probs_subset <- all_val_df %>% dplyr::filter(validation_status == 'problem') # subset of only problems
-
-  ok_subset <- all_val_df %>% dplyr::filter(validation_status != 'problem') # subset of ok values
-
-  validate_list <- list(all_req_files = !('missing_req_file' %in% probs_subset$validation_details),
-                        all_req_fields_in_req_files = !('missing_req_field' %in% probs_subset$validation_details),
-                        all_req_fields_in_opt_files = !('missing_req_field' %in% ok_subset$validation_details),
-                        full_column_and_file_validation_df = all_val_df)
-
-  # get subset of problem req files
-  if(!validate_list$all_req_files) {
-      validate_list$problem_req_files <- probs_subset %>%
-        dplyr::filter(grepl('missing_req_*', validation_details))%>%
-        dplyr::select(file, file_spec, file_provided_status, field, field_spec, field_provided_status)
-  }
-
-  # get subset of problem opt files
-  if(any(!validate_list$all_req_fields_in_req_files, !validate_list$all_req_fields_in_opt_files)) {
-      validate_list$problem_opt_files <- ok_subset %>%
-        dplyr::filter(grepl('missing_opt_*', validation_details)) %>%
-        dplyr::select(file, file_spec, file_provided_status, field, field_spec, field_provided_status)
-  }
-
-  # update gtfs_obj attributes with validation data
-  attributes(gtfs_obj) <- append(attributes(gtfs_obj), list(feed_validation_result = validate_list))
-
-  if (return_gtfs_obj) {
-    return(gtfs_obj)
-  } else {
-    return(validate_list)
-  }
-
-}
-
-is_files_validation_result <- function(files_validation_result) {
-  cnames <- colnames(files_validation_result)
-  return(
-    length(cnames) == 3 &
-      'file' %in% cnames &
-      'spec' %in% cnames &
-      'provided_status' %in% cnames &
-      is.logical(files_validation_result$provided_status)
-    ) 
-}
-
+#' Basic check if a given list is a gtfs object 
 is_gtfs_obj <- function(gtfs_obj) {
   obj_attributes <- attributes(gtfs_obj)
   return(
@@ -143,249 +90,4 @@ is_gtfs_obj <- function(gtfs_obj) {
     !is.null(obj_attributes$names) &
     !is.null(obj_attributes$validation_result)
   )
-}
-
-#' For a list of files, return information about whether they are part of the GTFS spec.
-#'
-#' @param file_list A list of files to be checked
-#'
-#' @return Dataframe will one row for all required and optional files per spec, 
-#'         plus one row for any other files provided (file), 
-#'         with an indication of these categories (spec), 
-#'         and a wheter the file is provided (provided)
-#' @noRd
-
-validate_file_list <- function(file_list) {
-  
-  file_list <- sapply(file_list,get_file_shortname)
-  
-  # Per spec, these are the required and optional files
-  all_req_files <- c('agency', 'stops', 'routes', 'trips', 'stop_times', 'calendar')
-  all_opt_files <- c(
-    'calendar_dates',
-    'fare_attributes',
-    'fare_rules',
-    'shapes',
-    'frequencies',
-    'transfers',
-    'feed_info'
-  )
-  other_opt_files <- c(
-    'calendar_attributes',
-    'directions',
-    'fare_rider_categories',
-    'farezone_attributes',
-    'rider_categories',
-    'route_directions',
-    'stop_attributes',
-    'timetable_stop_order',
-    'timetables'
-  )
-  all_spec_files <- c(all_req_files, all_opt_files)
-
-  # Get the names of all the dfs in the list for a gtfs_obj
-  feed_names_file <- unname(file_list)
-  
-  # Determine whether any of the files provided are neither required nor optional
-  extra_files <- feed_names_file[!(feed_names_file %in% all_spec_files)]
-
-  all_files <- c(all_spec_files, extra_files)
-
-  files_validation_result <- dplyr::data_frame(file = all_files, 
-                                 spec = c(rep('req', times = length(all_req_files)), 
-                                 rep('opt', times = length(all_opt_files)), 
-                                 rep('ext', times = length(extra_files))))
-
-  files_validation_result <- files_validation_result %>%
-    dplyr::mutate(provided_status = (file %in% feed_names_file))
-  
-  return(files_validation_result)
-}
-
-filepaths_to_read <- function(directory, files_validation_result) {
-  stopifnot(is_files_validation_result(files_validation_result))
-  
-  files <- files_validation_result %>% 
-    filter(spec %in% c('req', 'opt') & provided_status) %>% 
-    pull(file)
-  
-  paste0(directory, "/", files, ".txt")
-}
-
-#' Create dataframe of GTFS variable spec info
-#' @noRd
-
-make_var_val <- function() {
-
-  nms <- get_gtfs_meta() %>% names() # get names of each envir element
-
-  all_val_df <- get_gtfs_meta() %>%
-    lapply(. %>% as.data.frame(stringsAsFactors=FALSE) %>% dplyr::tbl_df(.)) # convert list data to tbl_df
-
-  all_val_df <- mapply(function(x,y) dplyr::mutate(.data=x, file = y), x = all_val_df, y = nms, SIMPLIFY=FALSE) %>%
-    dplyr::bind_rows() # assign new variable 'file' to each tbl_df based on names
-
-  all_val_df$. <- NULL
-  
-  return(all_val_df)
-
-}
-
-#' Validate variables provided vs spec
-#'
-#' @param files_validation_result The dataframe output of validate_file_list for a single feed
-#' @param gtfs_obj A 'gtfs' class object with components agency_df, etc.
-#'
-#' @return Dataframe with one record per file x column (columns in spec + any extra provided),
-#'         with file and field specs and file and field provided statuses
-#'
-#' @noRd
-
-validate_vars <- function(gtfs_obj) {
-
-  files_validation_result <- attributes(gtfs_obj)$files_validation_result
-
-  # Generate the df of files and fields per the GTFS spec
-  spec_vars_df <- make_var_val() %>%
-    dplyr::rename(field_spec = spec)
-
-  # the files that are provided for this gtfs_obj
-  val_files_df <- files_validation_result %>%
-    dplyr::rename(file_spec = spec, file_provided_status = provided_status) %>% 
-    filter(file_provided_status)
-
-  # Join file level data with variable level data - for files that were provided
-  vars_df <- suppressMessages(dplyr::left_join(val_files_df, spec_vars_df))
-
-  val_vars_df <- dplyr::data_frame()
-
-  val_cols <- val_files_df$file
-  val_cols_df <- paste0(val_cols, '_df')
-
-  # List variables provided for each file and join to determine field_provided
-  for (j in val_cols_df) {
-
-    temp_df <- gtfs_obj[[j]]
-    temp_names <- names(temp_df)
-
-    # Handle the case where a required file is missing
-    if (is.null(temp_df) || is.null(temp_names) || all(is.na(temp_names))) {
-      temp_vars_df <- dplyr::data_frame(file = gsub('_df', '', j), 
-                                        field = NA, 
-                                        field_provided_status = FALSE)
-    } else {
-      empty_field_status <- temp_df %>%
-        dplyr::summarize_all(dplyr::funs(all(is.na(.)))) %>% 
-        gather(key=field, value=is_empty_field)
-
-      temp_vars_df <- dplyr::data_frame(file = rep(gsub('_df', '', j), 
-                                                   length(temp_names)), 
-                                        field = temp_names)
-      
-      temp_vars_df <- dplyr::inner_join(temp_vars_df, empty_field_status, by='field') %>% 
-        mutate(field_provided_status = !is_empty_field, is_empty_field = NULL)
-    }
-
-    val_vars_df <- dplyr::bind_rows(val_vars_df, temp_vars_df)
-
-  }
-
-  # Join observed field provided status with spec info
-  all_val_df <- suppressMessages(dplyr::full_join(vars_df, val_vars_df))
-
-  orig_rows <- nrow(all_val_df)
-
-  # Now fill in special cases from join results
-
-  # 1) Extra fields provided in spec files
-  sub_all_val_df <- all_val_df %>%
-    dplyr::filter(!is.na(field_spec))
-
-  non_csv_df <- all_val_df %>%
-    dplyr::filter(is.na(field_spec) & is.na(field)) # NA field point to non-csv files
-
-  case_df <- all_val_df %>%
-    dplyr::filter(is.na(field_spec) & !is.na(field))
-
-  case_df <- case_df %>% dplyr::mutate(field_spec = 'ext')%>% 
-    dplyr::group_by(file) %>%
-    dplyr::mutate(file_spec = unique(sub_all_val_df$file_spec[sub_all_val_df$file == unique(file)]),
-           file_provided_status = unique(sub_all_val_df$file_provided_status[sub_all_val_df$file == unique(file)]))
-
-  # 2) field_provided_status is NA for spec fields not provided in files provided
-  sub_all_val_df$field_provided_status[is.na(sub_all_val_df$field_provided_status)] <- FALSE
-
-  # Put filled in parts back together
-  all_val_df <- dplyr::bind_rows(sub_all_val_df, case_df, non_csv_df)
-  if (nrow(all_val_df) != orig_rows) stop('Handling of special cases failed.')
-
-  # Check overall status for required files/fields
-  all_val_df <- all_val_df %>%
-    dplyr::mutate(validation_status = 'ok') # default ok
-
-  all_val_df <- all_val_df %>%
-    dplyr::mutate(validation_details = NA) %>% # default to NA
-    dplyr::mutate(validation_details = replace(validation_details, !file_provided_status & file_spec == 'opt', 'missing_opt_file')) %>% # optional file missing
-    dplyr::mutate(validation_details = replace(validation_details, !file_provided_status & file_spec == 'req', 'missing_req_file')) %>% # req file missing
-    dplyr::mutate(validation_details = replace(validation_details, file_provided_status & field_spec == 'req' & !field_provided_status, 'missing_req_field')) %>%
-    dplyr::mutate(validation_details = replace(validation_details, file_provided_status & field_spec == 'opt' & !field_provided_status, 'missing_opt_field'))
-
-  all_val_df <- all_val_df %>%
-  dplyr::mutate(validation_status = replace(validation_status, grepl('req_file', validation_details), 'problem'))
-
-  return(all_val_df)
-}
-
-#' checks for the missing calendar.txt 
-#' exception (see https://developers.google.com/transit/gtfs/reference/calendar_dates-file). 
-#' if the exception is TRUE, then calendar has its file spec set to 'extra'.
-#' @param all_val_df dataframe of all files and fields. returned from validate_vars_provided()
-#' @return corrected dataframe.
-#' @noRd
-
-calendar_exception_fix <- function(all_val_df) {
-
-  # see if missing calendar
-  missing_calendar <- all_val_df %>%
-    dplyr::filter(file == 'calendar') %>%
-    dplyr::pull('file_provided_status') %>%
-    unique()
-  
-  missing_calendar <- c('no') %in% missing_calendar
-
-  # see if calendar_dates file includes field `date`
-  has_date_field <- all_val_df %>%
-    dplyr::filter(file == 'calendar_dates') %>%
-    dplyr::filter(field == 'date') %>%
-    dplyr::pull('field_provided_status')
-
-  has_date_field <- c('yes') %in% missing_calendar
-
-  # if missing calendar.txt but calendar_dates.txt has 'date' field, then update validation status of calendar to 'ok'
-
-  if(all(missing_calendar, has_date_field)) {
-
-    all_val_df <- all_val_df %>%
-      dplyr::mutate(validation_status = dplyr::if_else(file == "calendar", "ok", validation_status)) %>%
-      dplyr::mutate(file_spec = dplyr::if_else(file == "calendar", "ext", file_spec))
-  }
-
-  return(all_val_df)
-
-}
-
-validate_feed <- function(files_validation_result, gtfs_list, quiet = FALSE) {
-  # check if valid 'gtfs'
-  check <- validate_gtfs_structure(files_validation_result, gtfs_list, return_gtfs_obj = FALSE, quiet = TRUE)
-  valid <- all(check$all_req_files, check$all_req_fields_in_req_files)
-  
-  if(!quiet) message("Testing data structure...")
-  if(valid) {
-    class(gtfs_list) <- 'gtfs'
-    if(!quiet) message("...passed. Valid GTFS object.\n")
-  } else {
-    if(!quiet) message("...failed. Invalid data structure.\n")
-  }
-  gtfs_list$validation <- check 
-  return(gtfs_list)
 }

--- a/R/validate.R
+++ b/R/validate.R
@@ -1,7 +1,4 @@
-validate_gtfs <- function(gtfs_obj) {
-  validate_gtfs_structure(gtfs_obj$files_validation_result, gtfs_obj)
-}
-
+# validate_gtfs
 
 #' Create validation list for a gtfs_obj. It provides an overview of the structure of all files that were imported.
 #'
@@ -67,7 +64,9 @@ validate_gtfs_structure <- function(files_validation_result, gtfs_obj, return_gt
 #' @noRd
 
 validate_file_list <- function(file_list) {
-
+  
+  file_list <- sapply(file_list,get_file_shortname)
+  
   # Per spec, these are the required and optional files
   all_req_files <- c('agency', 'stops', 'routes', 'trips', 'stop_times', 'calendar')
   all_opt_files <- c(
@@ -92,7 +91,7 @@ validate_file_list <- function(file_list) {
 
   # Get the names of all the dfs in the list for a gtfs_obj
   feed_names_file <- unname(file_list)
-
+  
   # Determine whether any of the files provided are neither required nor optional
   extra_files <- feed_names_file[!(feed_names_file %in% all_spec_files)]
 
@@ -106,7 +105,6 @@ validate_file_list <- function(file_list) {
   files_validation_result <- files_validation_result %>%
     dplyr::mutate(provided_status = ifelse((file %in% 
                                            feed_names_file), 'yes', 'no'))
-  
   return(files_validation_result)
 }
 
@@ -140,7 +138,7 @@ make_var_val <- function() {
 
 #' Validate variables provided vs spec
 #'
-#' @param file_validation_meta The dataframe output of validate_file_list for a single feed
+#' @param files_validation_result The dataframe output of validate_file_list for a single feed
 #' @param gtfs_obj A 'gtfs' class object with components agency_df, etc.
 #'
 #' @return Dataframe with one record per file x column (columns in spec + any extra provided),
@@ -282,9 +280,9 @@ calendar_exception_fix <- function(all_val_df) {
 
 }
 
-validate_feed <- function(gtfs_list, quiet = FALSE) {
+validate_feed <- function(files_validation_result, gtfs_list, quiet = FALSE) {
   # check if valid 'gtfs'
-  check <- validate_gtfs_structure(valid_files_meta, gtfs_list, return_gtfs_obj = FALSE, quiet = TRUE)
+  check <- validate_gtfs_structure(files_validation_result, gtfs_list, return_gtfs_obj = FALSE, quiet = TRUE)
   valid <- all(check$all_req_files, check$all_req_fields_in_req_files)
   
   if(!quiet) message("Testing data structure...")
@@ -296,5 +294,4 @@ validate_feed <- function(gtfs_list, quiet = FALSE) {
   }
   gtfs_list$validation <- check 
   return(gtfs_list)
-  
 }

--- a/R/validate.R
+++ b/R/validate.R
@@ -67,9 +67,7 @@ validate_gtfs_structure <- function(files_validation_result, gtfs_obj, return_gt
 #' @noRd
 
 validate_file_list <- function(file_list) {
-  
-  file_list <- sapply(file_list,get_file_shortname)
-  
+
   # Per spec, these are the required and optional files
   all_req_files <- c('agency', 'stops', 'routes', 'trips', 'stop_times', 'calendar')
   all_opt_files <- c(
@@ -94,7 +92,7 @@ validate_file_list <- function(file_list) {
 
   # Get the names of all the dfs in the list for a gtfs_obj
   feed_names_file <- unname(file_list)
-  
+
   # Determine whether any of the files provided are neither required nor optional
   extra_files <- feed_names_file[!(feed_names_file %in% all_spec_files)]
 
@@ -142,7 +140,7 @@ make_var_val <- function() {
 
 #' Validate variables provided vs spec
 #'
-#' @param files_validation_result The dataframe output of validate_file_list for a single feed
+#' @param file_validation_meta The dataframe output of validate_file_list for a single feed
 #' @param gtfs_obj A 'gtfs' class object with components agency_df, etc.
 #'
 #' @return Dataframe with one record per file x column (columns in spec + any extra provided),
@@ -284,9 +282,9 @@ calendar_exception_fix <- function(all_val_df) {
 
 }
 
-validate_feed <- function(files_validation_result, gtfs_list, quiet = FALSE) {
+validate_feed <- function(gtfs_list, quiet = FALSE) {
   # check if valid 'gtfs'
-  check <- validate_gtfs_structure(files_validation_result, gtfs_list, return_gtfs_obj = FALSE, quiet = TRUE)
+  check <- validate_gtfs_structure(valid_files_meta, gtfs_list, return_gtfs_obj = FALSE, quiet = TRUE)
   valid <- all(check$all_req_files, check$all_req_fields_in_req_files)
   
   if(!quiet) message("Testing data structure...")
@@ -298,4 +296,5 @@ validate_feed <- function(files_validation_result, gtfs_list, quiet = FALSE) {
   }
   gtfs_list$validation <- check 
   return(gtfs_list)
+  
 }

--- a/R/validate.R
+++ b/R/validate.R
@@ -37,6 +37,17 @@ validate_gtfs <- function(gtfs_obj) {
     validation_result <- rbind(validation_result, df_validation)
   }
   
+  # checks for the missing calendar.txt exception, see https://developers.google.com/transit/gtfs/reference/#calendar_datestxt
+  # if the exception is TRUE, then calendar has its file spec set to 'extra' and calendar_dates is required
+  calendar_exists <- validation_result %>% filter(file == "calendar") %>% pull(file_provided_status) %>% all()
+  if(!calendar_exists) {
+    validation_result <- validation_result %>% 
+      dplyr::mutate(file_spec = replace(file_spec, file == 'calendar', 'ext')) %>% 
+      dplyr::mutate(file_spec = replace(file_spec, file == 'calendar_dates', 'req'))
+  }
+  
+  
+  # check existign files and fields
   validation_result$validation_status <- 'ok'
   validation_result$validation_details <- NA
   

--- a/R/validate.R
+++ b/R/validate.R
@@ -1,4 +1,7 @@
-# validate_gtfs
+validate_gtfs <- function(gtfs_obj) {
+  validate_gtfs_structure(gtfs_obj$files_validation_result, gtfs_obj)
+}
+
 
 #' Create validation list for a gtfs_obj. It provides an overview of the structure of all files that were imported.
 #'
@@ -105,6 +108,7 @@ validate_file_list <- function(file_list) {
   files_validation_result <- files_validation_result %>%
     dplyr::mutate(provided_status = ifelse((file %in% 
                                            feed_names_file), 'yes', 'no'))
+  
   return(files_validation_result)
 }
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -61,7 +61,7 @@ validate_gtfs_structure <- function(file_validation_meta, gtfs_obj, return_gtfs_
 #' @return Dataframe will one row for all required and optional files per spec, plus one row for any other files provided (file), with an indication of these categories (spec), and a yes/no/empty status (provided_status)
 #' @noRd
 
-validate_files <- function(gtfs_file_prefixes) {
+validate_file_list <- function(file_list) {
 
   # Per spec, these are the required and optional files
   all_req_files <- c('agency', 'stops', 'routes', 'trips', 'stop_times', 'calendar')
@@ -86,7 +86,7 @@ validate_files <- function(gtfs_file_prefixes) {
   all_spec_files <- c(all_req_files, all_opt_files)
 
   # Get the names of all the dfs in the list for a gtfs_obj
-  feed_names_file <- unname(gtfs_file_prefixes)
+  feed_names_file <- unname(file_list)
 
   # Determine whether any of the files provided are neither required nor optional
   extra_files <- feed_names_file[!(feed_names_file %in% all_spec_files)]
@@ -123,7 +123,7 @@ make_var_val <- function() {
 
 #' Validate variables provided vs spec
 #'
-#' @param file_validation_meta The dataframe output of validate_files for a single feed
+#' @param file_validation_meta The dataframe output of validate_file_list for a single feed
 #' @param gtfs_obj A 'gtfs' class object with components agency_df, etc.
 #'
 #' @return Dataframe with one record per file x column (columns in spec + any extra provided),
@@ -260,4 +260,21 @@ calendar_exception_fix <- function(all_val_df) {
 
   return(all_val_df)
 
+}
+
+validate_feed <- function(gtfs_list, quiet = FALSE) {
+  # check if valid 'gtfs'
+  check <- validate_gtfs_structure(valid_files_meta, gtfs_list, return_gtfs_obj = FALSE, quiet = TRUE)
+  valid <- all(check$all_req_files, check$all_req_fields_in_req_files)
+  
+  if(!quiet) message("Testing data structure...")
+  if(valid) {
+    class(gtfs_list) <- 'gtfs'
+    if(!quiet) message("...passed. Valid GTFS object.\n")
+  } else {
+    if(!quiet) message("...failed. Invalid data structure.\n")
+  }
+  gtfs_list$validation <- check 
+  return(gtfs_list)
+  
 }

--- a/R/validate.R
+++ b/R/validate.R
@@ -15,11 +15,9 @@ validate_gtfs_structure <- function(gtfs_obj, return_gtfs_obj = TRUE, quiet = FA
     return(NULL)
   }
 
-  if(!quiet) message(gtfs_obj$agency_df$agency_name)
-
   files_validation_result <- attributes(gtfs_obj)$files_validation_result
   
-  all_val_df <- validate_vars(files_validation_result, gtfs_obj = gtfs_obj) %>%
+  all_val_df <- validate_vars(gtfs_obj) %>%
     calendar_exception_fix()
 
   probs_subset <- all_val_df %>% dplyr::filter(validation_status == 'problem') # subset of only problems
@@ -180,15 +178,11 @@ make_var_val <- function() {
 #'
 #' @noRd
 
-validate_vars <- function(files_validation_result, gtfs_obj) {
+validate_vars <- function(gtfs_obj) {
 
-  stopifnot(any(class(files_validation_result) == 'tbl_df'),
-    is_files_validation_result(files_validation_result))
+  files_validation_result <- attributes(gtfs_obj)$files_validation_result
 
-  # files_validation_result <- gtfs_obj$files_validation_result
-  gtfs_obj <- gtfs_obj[which(names(gtfs_obj) != "files_validation_result")]
-  
-  t# Generate the df of files and fields per the GTFS spec
+  # Generate the df of files and fields per the GTFS spec
   spec_vars_df <- make_var_val() %>%
     dplyr::rename(field_spec = spec)
 


### PR DESCRIPTION
This pull request separates reading and validation of files. All files within a feed are read to data frames. Files existing in the gtfs reference are read with the specified column types, all other files are read as characters. 

After reading the feed, the data frames are validated. This means, at this stage, it's checked whether a required file/field is available and warned accordingly. This approach also leads to a more streamlined validation code IMHO. Further validations such as checking id consistency and so on are also possible.

The base reading function reads all files within a directory, downloading and unzipping are handled before.

There are a lot of changes, so feedback is very much appreciated.

Closes  #19 
Closes #6  

A note on read_gtfs: I'd propose to keep the function as simple as possible, i.e. all data manipulation is done afterwards. This means that get_route_frequency and so on should be called via pipe outside read_gtfs. The reason for this: Some functions in frequencies.R rely on direction_id, which is an optional field. If we call get_route_frequency and gtfs_as_sf within read_gtfs, we get errors and the feed is not even loaded.