### PR TITLE
Read feed with lubridate::date

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -255,9 +255,11 @@ create_gtfs_object <- function(tmpdirpath, file_paths, quiet = FALSE) {
   if(!quiet) message('Reading files in feed... done.\n\n')
   
     
-  gtfs_obj <- validate_gtfs(gtfs_obj)
+  gtfs_obj <- validate_gtfs(gtfs_obj, quiet = quiet)
   
   stopifnot(is_gtfs_obj(gtfs_obj))
+  
+  if(!quiet) message("Reading gtfs feed completed.\n\n")
   
   return(gtfs_obj)
 }

--- a/R/import.R
+++ b/R/import.R
@@ -357,14 +357,14 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
     coltypes[!is.na(indx)] <- meta$coltype[indx[!is.na(indx)]] # valid cols found in small_df
 
     ## get colclasses for use in read.csv (useful when UTF-8-BOM encoding is found)
-    colclasses <- sapply(coltypes, switch, c = "character", i = "integer", d = "double")
+    colclasses <- sapply(coltypes, switch, c = "character", i = "integer", d = "double", "D" = "Date")
 
     ## collapse coltypes for use in read_csv
     coltypes <- coltypes %>% paste(collapse = "")
 
     ## switch function for when BOMs exist
     converttype <- function(x, y) {
-      switch(x, character = as.character(y), integer = as.integer(y), double = as.double(y))
+      switch(x, character = as.character(y), integer = as.integer(y), double = as.double(y), Date = ymd(y))
     }
 
     if (has_bom(file_path)) { # check for BOM. if yes, use read.csv()

--- a/R/import.R
+++ b/R/import.R
@@ -346,18 +346,18 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
     small_df <- suppressWarnings(utils::read.csv(file_path, nrows = 5, stringsAsFactors = FALSE)) # get a small df to find how many cols are needed
 
     ## get correct coltype, if possible
-    coltypes <- rep('c', dim(small_df)[2]) # create 'c' as coltype defaults
-    names(coltypes) <- names(small_df) %>% tolower()
-    indx <- match(names(coltypes), meta$field)  # indx from valid cols in meta$field. NAs will return for invalid cols
+    coltypes_character <- rep('c', dim(small_df)[2]) # create 'c' as coltype defaults
+    names(coltypes_character) <- names(small_df) %>% tolower()
+    indx <- match(names(coltypes_character), meta$field)  # indx from valid cols in meta$field. NAs will return for invalid cols
 
     ## !is.na(indx) = valid col in 'coltype' found in meta$field
     ## indx[!is.na(indx)] = location in 'meta$coltype' where corresponding type is found
-    coltypes[!is.na(indx)] <- meta$coltype[indx[!is.na(indx)]] # valid cols found in small_df
+    coltypes_character[!is.na(indx)] <- meta$coltype[indx[!is.na(indx)]] # valid cols found in small_df
 
     # use col_*() notation for column types
     coltypes <-
       sapply(
-        coltypes,
+        coltypes_character,
         switch,
         "c" = readr::col_character(),
         "i" = readr::col_integer(),
@@ -373,7 +373,7 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
       colnms <- meta$field[indx] # get expected/required names for columns. these are imposed.
       
       ## get colclasses
-      colclasses <- sapply(coltypes, switch, c = "character", i = "integer", d = "double", "D" = "Date")
+      colclasses <- sapply(coltypes_character, switch, c = "character", i = "integer", d = "double", "D" = "Date")
       
       csv <- quote(utils::read.csv(file_path, col.names = colnms, stringsAsFactors= FALSE))
       df <- try(suppressWarnings(eval(csv)) %>%

--- a/R/import.R
+++ b/R/import.R
@@ -394,7 +394,7 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
       
       if(dim(probs)[1] > 0) {
         attributes(df) <- append(attributes(df), list(problems = probs))
-        warning("Parsing failures while reading feed")
+        warning(paste0("Parsing failures while reading ", prefix))
         print(probs)
       }
     }

--- a/R/import.R
+++ b/R/import.R
@@ -84,8 +84,8 @@ read_gtfs <- function(path, local = FALSE,
 #' attach(sample_gtfs)
 #' #list routes by the number of stops they have
 #' routes_df %>% inner_join(trips_df, by="route_id") %>%
-#'   inner_join(stop_times_df) %>% 
-#'     inner_join(stops_df, by="stop_id") %>% 
+#'   inner_join(stop_times_df) %>%
+#'     inner_join(stops_df, by="stop_id") %>%
 #'       group_by(route_long_name) %>%
 #'         summarise(stop_count=n_distinct(stop_id)) %>%
 #'           arrange(desc(stop_count))

--- a/R/import.R
+++ b/R/import.R
@@ -250,7 +250,7 @@ create_gtfs_object <- function(tmpdirpath, file_paths, quiet = FALSE) {
                                               quiet = quiet))
   names(gtfs_obj) <- unname(df_names)
   if(!quiet) message('...done.\n\n')
-  
+  gtfs_obj[sapply(gtfs_obj, is.null)] <- NULL
   class(gtfs_obj) <- "gtfs"
   
   gtfs_obj <- validate_gtfs(gtfs_obj)
@@ -319,20 +319,20 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
     L <- suppressWarnings(length(scan(file_path, what = "", quiet = TRUE, sep = '\n')))
     if(L < 1) {
       s <- sprintf("   File '%s' is empty.", basename(file_path))
-      message(s)
+      if(!quiet) message(s)
       return(NULL)
     }
 
     # if no meta data is found for a file type but file is not empty, read as is.
     if(is.null(meta)) {
       s <- sprintf("   File %s not recognized, trying to read file as csv", basename(file_path))
-      message(s)
+      if(!quiet) message(s)
 
       tryCatch({
         df <- suppressMessages(readr::read_csv(file = file_path))
       }, error = function(error_condition) {
         s <- sprintf("   File could not be read as csv.", basename(file_path))
-        message(s)
+        if(!quiet) message(s)
         return(NULL)
       })
       return(df)

--- a/R/import.R
+++ b/R/import.R
@@ -244,15 +244,17 @@ unzip_file <- function(zipfile,
 create_gtfs_object <- function(tmpdirpath, file_paths, quiet = FALSE) {
   prefixes <- vapply(file_paths,get_file_shortname,FUN.VALUE = "")
   df_names <- paste(prefixes,"_df",sep="")
+  if(!quiet) message('Reading files in feed...\n')
   gtfs_obj <- lapply(file_paths, 
                    function(x) read_gtfs_file(x, 
                                               tmpdirpath, 
                                               quiet = quiet))
   names(gtfs_obj) <- unname(df_names)
-  if(!quiet) message('...done.\n\n')
   gtfs_obj[sapply(gtfs_obj, is.null)] <- NULL
   class(gtfs_obj) <- "gtfs"
+  if(!quiet) message('Reading files in feed... done.\n\n')
   
+    
   gtfs_obj <- validate_gtfs(gtfs_obj)
   
   stopifnot(is_gtfs_obj(gtfs_obj))
@@ -272,7 +274,7 @@ create_gtfs_object <- function(tmpdirpath, file_paths, quiet = FALSE) {
 read_gtfs_file <- function(file_path, tmpdirpath, quiet = FALSE) {
   prefix <- get_file_shortname(file_path)
 
-  if(!quiet) message(paste0('Reading ', df_name))
+  if(!quiet) message(paste0('Reading ', prefix))
 
   full_file_path <- paste0(tmpdirpath,"/",file_path)
   new_df <- parse_gtfs_file(prefix, full_file_path, quiet = quiet)
@@ -325,7 +327,7 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
 
     # if no meta data is found for a file type but file is not empty, read as is.
     if(is.null(meta)) {
-      s <- sprintf("   File %s not recognized, trying to read file as csv", basename(file_path))
+      s <- sprintf("   File %s not recognized, trying to read file as csv.", basename(file_path))
       if(!quiet) message(s)
 
       tryCatch({

--- a/R/import.R
+++ b/R/import.R
@@ -252,7 +252,7 @@ create_gtfs_object <- function(tmpdirpath, file_paths, quiet = FALSE) {
   names(gtfs_obj) <- unname(df_names)
   gtfs_obj[sapply(gtfs_obj, is.null)] <- NULL
   class(gtfs_obj) <- "gtfs"
-  if(!quiet) message('Reading files in feed... done.\n\n')
+  if(!quiet) message('Reading files in feed... done.\n')
   
     
   gtfs_obj <- validate_gtfs(gtfs_obj, quiet = quiet)
@@ -364,7 +364,7 @@ parse_gtfs_file <- function(prefix, file_path, quiet = FALSE) {
 
     ## switch function for when BOMs exist
     converttype <- function(x, y) {
-      switch(x, character = as.character(y), integer = as.integer(y), double = as.double(y), Date = ymd(y))
+      switch(x, character = as.character(y), integer = as.integer(y), double = as.double(y), Date = lubridate::ymd(y))
     }
 
     if (has_bom(file_path)) { # check for BOM. if yes, use read.csv()

--- a/R/spec.R
+++ b/R/spec.R
@@ -59,7 +59,8 @@ get_gtfs_meta <- function() {
   calendar$field_spec[2] <- 'opt'
   names(calendar$field_spec) <- calendar$field
   calendar$coltype <- rep('i', length(calendar$field))
-  calendar$coltype[calendar$field %in% c('service_id', 'service_name', 'start_date', 'end_date')] <- 'c'
+  calendar$coltype[calendar$field %in% c('service_id', 'service_name')] <- 'c'
+  calendar$coltype[calendar$field %in% c('start_date', 'end_date')] <- 'D'
   calendar$file_spec <- 'req'
 
   # optional files ----------------------------------------------------------
@@ -71,6 +72,7 @@ get_gtfs_meta <- function() {
   names(calendar_dates$field_spec) <- calendar_dates$field
   calendar_dates$coltype <- rep('c', length(calendar_dates$field))
   calendar_dates$coltype[calendar_dates$field %in% c('exception_type')] <- 'i'
+  calendar_dates$coltype[calendar_dates$field %in% c('date')] <- 'D'
   calendar_dates$file_spec <- 'opt'
   
   # fare_attributes
@@ -128,6 +130,7 @@ get_gtfs_meta <- function() {
   feed_info$field_spec[c(2:4)] <- 'req'
   names(feed_info$field_spec) <- feed_info$field
   feed_info$coltype <- rep('c', length(feed_info$field))
+  feed_info$coltype[transfers$field %in% c('feed_start_date', 'feed_end_date')] <- 'D'
   feed_info$file_spec <- 'opt'
   
   meta <- list(agency, stops, routes, trips, stop_times, calendar, calendar_dates, fare_attributes, fare_rules, shapes, frequencies, transfers, feed_info)

--- a/R/spec.R
+++ b/R/spec.R
@@ -26,11 +26,11 @@ get_gtfs_meta <- function() {
   
   # routes
   assign("routes", list())
-  routes$field <- c('route_id', 'agency_id', 'route_short_name', 'route_long_name', 'route_desc', 'route_type', 'route_url', 'route_color', 'route_text_color', 'route_sort_order', 'min_headway_minutes')
-  routes$field_spec <- c('req', 'opt', 'req', 'req', 'opt', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
+  routes$field <- c('route_id', 'agency_id', 'route_short_name', 'route_long_name', 'route_desc', 'route_type', 'route_url', 'route_color', 'route_text_color', 'route_sort_order')
+  routes$field_spec <- c('req', 'opt', 'req', 'req', 'opt', 'req', 'opt', 'opt', 'opt', 'opt')
   names(routes$field_spec) <- routes$field
   routes$coltype <- rep('c', length(routes$field))
-  routes$coltype[routes$field %in% c('route_type', 'route_sort_order', 'min_headway_minutes')] <- 'i'
+  routes$coltype[routes$field %in% c('route_type', 'route_sort_order')] <- 'i'
   routes$file_spec <- 'req'
   
   # trips

--- a/R/time.R
+++ b/R/time.R
@@ -19,11 +19,11 @@ gt_as_dt <- function(stop_times_df) {
 #' @return dataframe with only stop times within the hours specified, with time columns as lubridate periods
 #' @keywords internal
 filter_stop_times_by_hour <- function(stop_times, 
-                                      start_hour, 
-                                      end_hour) {
+  start_hour, 
+  end_hour) {
   stop_times_dt <- gt_as_dt(stop_times)
   stop_times <- stop_times[lubridate::hour(stop_times_dt$arrival_time) > start_hour &
-                     lubridate::hour(stop_times_dt$departure_time) < end_hour,]
+      lubridate::hour(stop_times_dt$departure_time) < end_hour,]
   return(stop_times)
 }
 
@@ -63,41 +63,50 @@ set_hms_times <- function(gtfs_obj) {
 set_date_service_table <- function(gtfs_obj) {
   stopifnot(is_gtfs_obj(gtfs_obj))
   
-  # table to connect every date to corresponding services (all dates from earliest to latest)
-  dates <- dplyr::tibble(
-    date = seq(
-      min(gtfs_obj$calendar_df$start_date),
-      max(gtfs_obj$calendar_df$end_date),
-      1
-    ),
-    weekday = tolower(weekdays(date))
-  )
-  
-  # gather services by weekdays
-  service_ids_weekdays <-
-    tidyr::gather(
-      gtfs_obj$calendar_df,
-      key = "weekday",
-      value = "bool",
-      -c(service_id, start_date, end_date)
-    ) %>%
-    dplyr::filter(bool == 1) %>% dplyr::select(-bool)
-  
-  # set services to dates according to weekdays and start/end date
-  date_service_df <- dplyr::full_join(dates, service_ids_weekdays, by="weekday") %>% 
-    dplyr::filter(date > start_date & date < end_date) %>% 
-    dplyr::select(-weekday, -start_date, -end_date)
+  if(all(is.na(gtfs_obj$calendar_df$start_date)) & all(is.na(gtfs_obj$calendar_df$start_date))) {
+    # TODO validate no start_date and end_date defined in calendar.txt
+    date_service_df <- dplyr::tibble(date=lubridate::ymd("19700101"), service_id="x") %>% dplyr::filter(service_id != "x")
+  } else {
+    # table to connect every date to corresponding services (all dates from earliest to latest)
+    dates <- dplyr::tibble(
+      date = seq(
+        min(gtfs_obj$calendar_df$start_date, na.rm = T),
+        max(gtfs_obj$calendar_df$end_date, na.rm = T),
+        1
+      ),
+      weekday = tolower(weekdays(date))
+    )
+    
+    # gather services by weekdays
+    service_ids_weekdays <-
+      tidyr::gather(
+        gtfs_obj$calendar_df,
+        key = "weekday",
+        value = "bool",
+        -c(service_id, start_date, end_date)
+      ) %>%
+      dplyr::filter(bool == 1) %>% dplyr::select(-bool)
+    
+    # set services to dates according to weekdays and start/end date
+    date_service_df <- dplyr::full_join(dates, service_ids_weekdays, by="weekday") %>% 
+      dplyr::filter(date > start_date & date < end_date) %>% 
+      dplyr::select(-weekday, -start_date, -end_date)
+  }
   
   # add calendar_dates additions (1) 
   additions = gtfs_obj$calendar_dates_df %>% filter(exception_type == 1) %>% select(-exception_type)
   if(nrow(additions) > 0) {
     date_service_df <- dplyr::full_join(date_service_df, additions, by=c("date", "service_id"))
   }
-
+  
   # remove calendar_dates exceptions (2) 
   exceptions = gtfs_obj$calendar_dates_df %>% filter(exception_type == 2) %>% select(-exception_type)
   if(nrow(exceptions) > 0) {
     date_service_df <- dplyr::anti_join(date_service_df, exceptions, by=c("date", "service_id"))
+  }
+  
+  if(nrow(date_service_df) == 0) {
+    warning("No start and end dates defined in feed")
   }
   
   gtfs_obj$date_service <- date_service_df

--- a/R/time.R
+++ b/R/time.R
@@ -27,6 +27,23 @@ filter_stop_times_by_hour <- function(stop_times,
   return(stop_times)
 }
 
+#' Adds columns to stop_times (arrival_time, departure_time) and frequencies (start_time_hms, end_time_hms)
+#' with times converted with lubridate::hms().
+#' 
+#' @return gtfs_obj with added hms times columns for stop_times_df and frequencies_df
+#' @importFrom lubridate hms
+create_hms_times <- function(gtfs_obj) {
+  gtfs_obj$stop_times_df$arrival_time_hms <- lubridate::hms(gtfs_obj$stop_times_df$arrival_time, quiet=T)
+  gtfs_obj$stop_times_df$departure_time_hms <- lubridate::hms(gtfs_obj$stop_times_df$departure_time, quiet=T)
+  
+  if(!is.null(gtfs_obj$frequencies_df)) {
+    gtfs_obj$frequencies_df$start_time_hms <- lubridate::hms(gtfs_obj$frequencies_df$start_time, quiet=T)
+    gtfs_obj$frequencies_df$end_time_hms <- lubridate::hms(gtfs_obj$frequencies_df$end_time, quiet=T)
+  }
+  
+  return(gtfs_obj)
+}
+
 #' Create a m:n table showing which service runs on which date.
 #' 
 #' @return gtfs_obj with added date_service data frame

--- a/R/validate.R
+++ b/R/validate.R
@@ -39,8 +39,8 @@ validate_gtfs <- function(gtfs_obj, quiet = T) {
       w <- paste0("Invalid feed. Missing required field(s): ", paste(missing_req_fields, collapse=", "))
       warning(w)
     }
-  } else {
-    if(!quiet) message("Valid gtfs data structure")
+  } else if(!quiet) {
+    message("Valid gtfs data structure.")
   }
   
   # assign validation result to gtfs_obj

--- a/R/validate.R
+++ b/R/validate.R
@@ -6,7 +6,7 @@
 #' @return gtfs_obj with a validation summary dataframe as an attribute 
 #' 
 #' @noRd
-validate_gtfs <- function(gtfs_obj) {
+validate_gtfs <- function(gtfs_obj, quiet = T) {
 
   validation_result <- validate_gtfs_structure(gtfs_obj)
   
@@ -40,7 +40,7 @@ validate_gtfs <- function(gtfs_obj) {
       warning(w)
     }
   } else {
-    message("Valid gtfs data structure")
+    if(!quiet) message("Valid gtfs data structure")
   }
   
   # assign validation result to gtfs_obj


### PR DESCRIPTION
With this PR, dates in calendar.txt, calendar_dates.txt and feed_info.txt are read with `lubridate::date`. The gtfs specification states that dates have to be provided as YYYYMMDD and I'd say reading them as dates instead of characters makes further data analysis easier.

There are two new helper methods in time.R
- `set_date_service_table(gtfs_obj)` adds a data frame to the gtfs object that stores which services run on which dates. The resulting `gtfs_obj$date_service` looks like this.
```
   date       service_id
   <date>     <chr>     
 1 2017-12-11 b07sy  
 2 2017-12-11 b0nbk  
 3 2017-12-11 b0nbn  
 4 2017-12-12 a0nbx  
 5 2017-12-12 a0nc7  
```
This can then be used to analyse the dates with most services and trips (e.g. by joining tables and using summary).
- `set_hms_times(gtfs_obj)` adds lubridate::hms() columns where possible. The existing character columns are not replaced to ensure compability. Times are a bit more erratic when it comes to parsing (with possible hours > 24) that's why conversion is not done while reading the feed.

Minor changes:
- When parsing failures occur, the problem table is printed to the console
- Empty files are not added to gtfs_obj
- quiet is completely quiet for messages
- min_headway_minutes was removed from spec