### PR TITLE
Switch from lubridate to hms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     rlang,
     sf,
     lubridate,
+    hms,
     tidyr,
     tools
 Suggests:

--- a/R/time.R
+++ b/R/time.R
@@ -59,7 +59,7 @@ set_hms_times <- function(gtfs_obj) {
 #' Returns all possible date/service_id combinations as a data frame
 #' 
 #' Use it to summarise service. For example, get a count of the number of services for a date. See example. 
-#' @return gtfs_obj with added date_service data frame
+#' @return a date_service data frame
 #' @param gtfs_obj a gtfs_object as read by read_gtfs
 #' @export
 #' @examples 

--- a/R/time.R
+++ b/R/time.R
@@ -74,6 +74,10 @@ set_hms_times <- function(gtfs_obj) {
 get_date_service_table <- function(gtfs_obj) {
   stopifnot(is_gtfs_obj(gtfs_obj))
   
+  weekday <- function(date) {
+    c("sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday")[as.POSIXlt(date)$wday + 1]
+  }
+  
   if(all(is.na(gtfs_obj$calendar_df$start_date)) & all(is.na(gtfs_obj$calendar_df$end_date))) {
     # TODO validate no start_date and end_date defined in calendar.txt
     date_service_df <- dplyr::tibble(date=lubridate::ymd("19700101"), service_id="x") %>% dplyr::filter(service_id != "x")
@@ -85,7 +89,7 @@ get_date_service_table <- function(gtfs_obj) {
         max(gtfs_obj$calendar_df$end_date, na.rm = T),
         1
       ),
-      weekday = tolower(weekdays(date))
+      weekday = weekday(date)
     )
     
     # gather services by weekdays

--- a/R/time.R
+++ b/R/time.R
@@ -27,14 +27,14 @@ filter_stop_times_by_hour <- function(stop_times,
   return(stop_times)
 }
 
-#' Add lubridate::hms columns to feed
+#' Add hms::hms columns to feed
 #' 
 #' Adds columns to stop_times (arrival_time_hms, departure_time_hms) and frequencies (start_time_hms, end_time_hms)
-#' with times converted with lubridate::hms().
+#' with times converted with hms::hms().
 #' 
 #' @return gtfs_obj with added hms times columns for stop_times_df and frequencies_df
 #' @keywords internal
-#' @importFrom lubridate hms
+#' @importFrom hms hms
 set_hms_times <- function(gtfs_obj) {
   stopifnot(is_gtfs_obj(gtfs_obj))
   

--- a/R/time.R
+++ b/R/time.R
@@ -38,12 +38,19 @@ filter_stop_times_by_hour <- function(stop_times,
 set_hms_times <- function(gtfs_obj) {
   stopifnot(is_gtfs_obj(gtfs_obj))
   
-  gtfs_obj$stop_times_df$arrival_time_hms <- lubridate::hms(gtfs_obj$stop_times_df$arrival_time, quiet=T)
-  gtfs_obj$stop_times_df$departure_time_hms <- lubridate::hms(gtfs_obj$stop_times_df$departure_time, quiet=T)
+  str_to_seconds <- function(hhmmss_str) {
+    sapply(
+      strsplit(hhmmss_str, ":"), 
+      function(Y) { sum(as.numeric(Y) * c(3600, 60, 1)) }
+      )
+  }
+  
+  gtfs_obj$stop_times_df$arrival_time_hms <- hms::hms(str_to_seconds(gtfs_obj$stop_times_df$arrival_time))
+  gtfs_obj$stop_times_df$departure_time_hms <- hms::hms(str_to_seconds(gtfs_obj$stop_times_df$departure_time))
   
   if(!is.null(gtfs_obj$frequencies_df)) {
-    gtfs_obj$frequencies_df$start_time_hms <- lubridate::hms(gtfs_obj$frequencies_df$start_time, quiet=T)
-    gtfs_obj$frequencies_df$end_time_hms <- lubridate::hms(gtfs_obj$frequencies_df$end_time, quiet=T)
+    gtfs_obj$frequencies_df$start_time_hms <- hms::hms(str_to_seconds(gtfs_obj$frequencies_df$start_time))
+    gtfs_obj$frequencies_df$end_time_hms <- hms::hms(str_to_seconds(gtfs_obj$frequencies_df$end_time))
   }
   
   return(gtfs_obj)

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -1,0 +1,33 @@
+context('Time manipulation')
+
+create_empty_gtfs_obj <- function() {
+  g <- list()
+  class(g) <- "gtfs"
+  attributes(g)$validation_result <- data.frame()
+  return(g)
+}
+
+test_that('set_hms_times() works with valid data', {
+  gtest <- create_empty_gtfs_obj()
+  gtest$stop_times_df <- dplyr::tibble(
+    arrival_time = c("08:00:00", "14:00:00", "26:10:00"),
+    departure_time = c("08:00:10", "14:00:20", "26:10:30"))
+  gtest$frequencies_df = dplyr::tibble(
+    start_time = c("06:00:00"),
+    end_time = c("12:00:00")
+  )
+
+  gtest <- tidytransit::set_hms_times(gtest)  
+  
+  expect_is(gtest$stop_times_df$arrival_time_hms, "hms")
+  expect_is(gtest$stop_times_df$departure_time_hms, "hms")
+  expect_is(gtest$stop_times_df$arrival_time, "character")
+  expect_is(gtest$stop_times_df$departure_time, "character")
+  expect_false(is.na(gtest$stop_times_df$arrival_time_hms[3]))
+  expect_equal(gtest$stop_times_df$departure_time_hms[3], hms::hms(26*3600+10*60+30))
+  
+  expect_is(gtest$frequencies_df$start_time_hms, "hms")
+  expect_is(gtest$frequencies_df$end_time_hms, "hms")
+  expect_is(gtest$frequencies_df$start_time, "character")
+  expect_is(gtest$frequencies_df$end_time, "character")
+})

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -32,7 +32,7 @@ test_that('set_hms_times() works with valid data', {
   expect_is(gtest$frequencies_df$end_time, "character")
 })
 
-test_that('set_date_service_table() uses the right dates', { 
+test_that('get_date_service_table() uses the right dates', { 
   gtest <- create_empty_gtfs_obj()
   gtest$calendar_df <- dplyr::tibble(
     service_id = "s1",
@@ -46,14 +46,14 @@ test_that('set_date_service_table() uses the right dates', {
     start_date = lubridate::ymd("20180101"), # monday
     end_date = lubridate::ymd("20180131")) # wednesday
 
-  gtest <- tidytransit::set_date_service_table(gtest)
+  date_service <- tidytransit::get_date_service_table(gtest)
   
-  expect_true(lubridate::ymd("20180101") %in% gtest$date_service$date)
-  expect_false(lubridate::ymd("20180102") %in% gtest$date_service$date)
-  expect_true(lubridate::ymd("20180131") %in% gtest$date_service$date)
+  expect_true(lubridate::ymd("20180101") %in% date_service$date)
+  expect_false(lubridate::ymd("20180102") %in% date_service$date)
+  expect_true(lubridate::ymd("20180131") %in% date_service$date)
 })
 
-test_that('set_date_service_table() works with additions and exceptions', { 
+test_that('get_date_service_table() works with additions and exceptions', { 
   gtest <- create_empty_gtfs_obj()
   gtest$calendar_df <- dplyr::tibble(
     service_id = c("wdays", "wend"),
@@ -72,23 +72,23 @@ test_that('set_date_service_table() works with additions and exceptions', {
     exception_type = c(2, 1)
   )
   
-  gtest <- tidytransit::set_date_service_table(gtest)
+  date_service <- tidytransit::get_date_service_table(gtest)
   
   # exception
-  mar14 <- gtest$date_service[gtest$date_service$date == lubridate::ymd("20180613"),]
+  mar14 <- date_service[date_service$date == lubridate::ymd("20180613"),]
   expect_equal(nrow(mar14), 0)
   
   # addition
-  feb26 <- gtest$date_service[gtest$date_service$date == lubridate::ymd("20180226"),] # monday
+  feb26 <- date_service[date_service$date == lubridate::ymd("20180226"),] # monday
   expect_equal(nrow(feb26), 2)
   
   # overlaps
-  apr05 <- gtest$date_service[gtest$date_service$date == lubridate::ymd("20180405"),] # thursday
+  apr05 <- date_service[date_service$date == lubridate::ymd("20180405"),] # thursday
   expect_equal(apr05 %>% dplyr::group_by(date) %>% dplyr::count() %>% dplyr::pull(n), 1)
-  apr06 <- gtest$date_service[gtest$date_service$date == lubridate::ymd("20180406"),] # friday
+  apr06 <- date_service[date_service$date == lubridate::ymd("20180406"),] # friday
   expect_equal(apr06 %>% dplyr::group_by(date) %>% dplyr::count() %>% dplyr::pull(n), 2)
   
-  range <- gtest$date_service %>% 
+  range <- date_service %>% 
     dplyr::group_by(service_id) %>% 
     dplyr::summarise(min = min(date), max=max(date))
   expect_equal(range[range$service_id == "wdays", "min"], dplyr::tibble(min=lubridate::ymd("20180201")))

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -31,3 +31,66 @@ test_that('set_hms_times() works with valid data', {
   expect_is(gtest$frequencies_df$start_time, "character")
   expect_is(gtest$frequencies_df$end_time, "character")
 })
+
+test_that('set_date_service_table() uses the right dates', { 
+  gtest <- create_empty_gtfs_obj()
+  gtest$calendar_df <- dplyr::tibble(
+    service_id = "s1",
+    monday = 1,
+    tuesday = 0,
+    wednesday = 1,
+    thursday = 0,
+    friday = 0,
+    saturday = 0,
+    sunday = 0,
+    start_date = lubridate::ymd("20180101"), # monday
+    end_date = lubridate::ymd("20180131")) # wednesday
+
+  gtest <- tidytransit::set_date_service_table(gtest)
+  
+  expect_true(lubridate::ymd("20180101") %in% gtest$date_service$date)
+  expect_false(lubridate::ymd("20180102") %in% gtest$date_service$date)
+  expect_true(lubridate::ymd("20180131") %in% gtest$date_service$date)
+})
+
+test_that('set_date_service_table() works with additions and exceptions', { 
+  gtest <- create_empty_gtfs_obj()
+  gtest$calendar_df <- dplyr::tibble(
+    service_id = c("wdays", "wend"),
+    monday = c(1, 0),
+    tuesday = c(1, 0),
+    wednesday = c(1, 0),
+    thursday = c(1, 0),
+    friday = c(1, 1),
+    saturday = c(0, 1),
+    sunday = c(0, 1),
+    start_date = c(lubridate::ymd("20180201"), lubridate::ymd("20180401")),
+    end_date = c(lubridate::ymd("20180430"), lubridate::ymd("20180430")))
+  gtest$calendar_dates_df = dplyr::tibble(
+    service_id = c("wdays", "wend"),
+    date = c(lubridate::ymd("20180314"), lubridate::ymd("20180226")),
+    exception_type = c(2, 1)
+  )
+  
+  gtest <- tidytransit::set_date_service_table(gtest)
+  
+  # exception
+  mar14 <- gtest$date_service[gtest$date_service$date == lubridate::ymd("20180613"),]
+  expect_equal(nrow(mar14), 0)
+  
+  # addition
+  feb26 <- gtest$date_service[gtest$date_service$date == lubridate::ymd("20180226"),] # monday
+  expect_equal(nrow(feb26), 2)
+  
+  # overlaps
+  apr05 <- gtest$date_service[gtest$date_service$date == lubridate::ymd("20180405"),] # thursday
+  expect_equal(apr05 %>% dplyr::group_by(date) %>% dplyr::count() %>% dplyr::pull(n), 1)
+  apr06 <- gtest$date_service[gtest$date_service$date == lubridate::ymd("20180406"),] # friday
+  expect_equal(apr06 %>% dplyr::group_by(date) %>% dplyr::count() %>% dplyr::pull(n), 2)
+  
+  range <- gtest$date_service %>% 
+    dplyr::group_by(service_id) %>% 
+    dplyr::summarise(min = min(date), max=max(date))
+  expect_equal(range[range$service_id == "wdays", "min"], dplyr::tibble(min=lubridate::ymd("20180201")))
+  expect_equal(range[range$service_id == "wend", "max"], dplyr::tibble(max=lubridate::ymd("20180429")))
+})

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -17,7 +17,7 @@ test_that('set_hms_times() works with valid data', {
     end_time = c("12:00:00")
   )
 
-  gtest <- tidytransit::set_hms_times(gtest)  
+  gtest <- tidytransit:::set_hms_times(gtest)  
   
   expect_is(gtest$stop_times_df$arrival_time_hms, "hms")
   expect_is(gtest$stop_times_df$departure_time_hms, "hms")
@@ -46,7 +46,7 @@ test_that('get_date_service_table() uses the right dates', {
     start_date = lubridate::ymd("20180101"), # monday
     end_date = lubridate::ymd("20180131")) # wednesday
 
-  date_service <- tidytransit::get_date_service_table(gtest)
+  date_service <- tidytransit:::get_date_service_table(gtest)
   
   expect_true(lubridate::ymd("20180101") %in% date_service$date)
   expect_false(lubridate::ymd("20180102") %in% date_service$date)
@@ -72,7 +72,7 @@ test_that('get_date_service_table() works with additions and exceptions', {
     exception_type = c(2, 1)
   )
   
-  date_service <- tidytransit::get_date_service_table(gtest)
+  date_service <- tidytransit:::get_date_service_table(gtest)
   
   # exception
   mar14 <- date_service[date_service$date == lubridate::ymd("20180613"),]


### PR DESCRIPTION
Sorry for the kinda erratic development but I had to revisit #26. Apparently tidyverse functions don't work with lubridate ([see github issue](https://github.com/tidyverse/dplyr/issues/2432)). That's why I changed the implementation of `set_hms_times` to work with `hms::hms`. That way, joining and otherwise filtering tables seems to work. The time functions of lubridate would've been a bit overkill anyways, since we don't have to work with timezones and so on.

Maybe more important: There's now tests covering the two methods added in #26. I also fixed a bug with date ranges.