### PR TITLE
Use test feed on repository

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -37,6 +37,7 @@ read_gtfs <- function(path, local = FALSE,
   # download zip file
   if(!local) {
     path <- download_from_url(url = path, quiet = quiet)
+    if(is.null(path)) { return() }
   }
   
   # extract zip file
@@ -120,13 +121,9 @@ download_from_url <- function(url, path=tempfile(fileext = ".zip"), quiet=FALSE)
   }
   
   # check if url links to a zip file
-  valid <- valid_url(url)
-  if(!valid) {
-    if(!quiet) {
-      stop1 <- sprintf("Link '%s' is invalid; failed to connect. NULL was returned.", url)
-      stop(stop1)
-    }
-    return(NULL)
+  if(!valid_url(url)) {
+    stop1 <- sprintf("Link '%s' is invalid; failed to connect.", url)
+    stop(stop1)
   }
   
   r <- httr::GET(url)
@@ -149,7 +146,7 @@ download_from_url <- function(url, path=tempfile(fileext = ".zip"), quiet=FALSE)
   check <- try(normalizePath(path), silent = TRUE)
   if(assertthat::is.error(check)) {
     warn <- 'Invalid file path. NULL is returned.'
-    if(!quiet) warning(warn)
+    warning(warn)
     return(NULL)
   }
   return(path)

--- a/R/import.R
+++ b/R/import.R
@@ -19,7 +19,7 @@
 #' @importFrom dplyr %>% arrange summarise group_by inner_join
 #' @examples \donttest{
 #' library(dplyr)
-#' u1 <- "https://developers.google.com/transit/gtfs/examples/sample-feed.zip"
+#' u1 <- "https://github.com/r-transit/tidytransit/raw/master/inst/extdata/sample-feed-fixed.zip"
 #' sample_gtfs <- read_gtfs(u1)
 #' attach(sample_gtfs)
 #' #list routes by the number of stops they have
@@ -80,7 +80,7 @@ read_gtfs <- function(path, local = FALSE,
 #' @importFrom dplyr %>% arrange summarise group_by inner_join
 #' @examples \donttest{
 #' library(dplyr)
-#' u1 <- "https://developers.google.com/transit/gtfs/examples/sample-feed.zip"
+#' u1 <- "https://github.com/r-transit/tidytransit/raw/master/inst/extdata/sample-feed-fixed.zip"
 #' sample_gtfs <- import_gtfs(u1)
 #' attach(sample_gtfs)
 #' #list routes by the number of stops they have

--- a/R/spec.R
+++ b/R/spec.R
@@ -21,7 +21,7 @@ get_gtfs_meta <- function() {
   names(stops$field_spec) <- stops$field
   stops$coltype <- rep('c', length(stops$field))
   stops$coltype[which(stops$field %in% c('stop_lat', 'stop_lon'))] <- 'd' # double
-  stops$coltype[which(stops$field %in% c('location_type', 'parent_station', 'wheelchair_boarding'))] <- 'i' #integers
+  stops$coltype[which(stops$field %in% c('location_type', 'wheelchair_boarding'))] <- 'i' #integers
   stops$file_spec <- 'req'
   
   # routes

--- a/R/spec.R
+++ b/R/spec.R
@@ -21,7 +21,7 @@ get_gtfs_meta <- function() {
   names(stops$field_spec) <- stops$field
   stops$coltype <- rep('c', length(stops$field))
   stops$coltype[which(stops$field %in% c('stop_lat', 'stop_lon'))] <- 'd' # double
-  stops$coltype[which(stops$field %in% c('location_type', 'wheelchair_boarding'))] <- 'i' #integers
+  stops$coltype[which(stops$field %in% c('location_type', 'parent_station', 'wheelchair_boarding'))] <- 'i' #integers
   stops$file_spec <- 'req'
   
   # routes
@@ -54,12 +54,11 @@ get_gtfs_meta <- function() {
   
   # calendar
   assign("calendar", list())
-  calendar$field <- c('service_id', 'service_name', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday', 'start_date', 'end_date')
+  calendar$field <- c('service_id', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday', 'start_date', 'end_date')
   calendar$field_spec <- rep('req', times = length(calendar$field))
-  calendar$field_spec[2] <- 'opt'
   names(calendar$field_spec) <- calendar$field
   calendar$coltype <- rep('i', length(calendar$field))
-  calendar$coltype[calendar$field %in% c('service_id', 'service_name')] <- 'c'
+  calendar$coltype[calendar$field %in% c('service_id')] <- 'c'
   calendar$coltype[calendar$field %in% c('start_date', 'end_date')] <- 'D'
   calendar$file_spec <- 'req'
 
@@ -120,14 +119,13 @@ get_gtfs_meta <- function() {
   transfers$field_spec <- c('req', 'req', 'req', 'opt')
   names(transfers$field_spec) <- transfers$field
   transfers$coltype <- rep('c', length(transfers$field))
-  transfers$coltype[transfers$field %in% c('exception_type', 'min_transfer_time')] <- 'i'
+  transfers$coltype[transfers$field %in% c('min_transfer_time')] <- 'i'
   transfers$file_spec <- 'opt'
   
   # feed_info
   assign("feed_info", list())
-  feed_info$field <- c('feed_id', 'feed_publisher_name', 'feed_publisher_url', 'feed_lang', 'feed_version', 'feed_license', 'feed_contact_email', 'feed_contact_url', 'feed_start_date', 'feed_end_date')
-  feed_info$field_spec <- rep('opt', times = length(feed_info$field))
-  feed_info$field_spec[c(2:4)] <- 'req'
+  feed_info$field <- c('feed_publisher_name', 'feed_publisher_url', 'feed_lang', 'feed_start_date', 'feed_end_date', 'feed_version', 'feed_contact_email', 'feed_contact_url')
+  feed_info$field_spec <- c('req', 'req', 'req', 'opt', 'opt', 'opt', 'opt', 'opt')
   names(feed_info$field_spec) <- feed_info$field
   feed_info$coltype <- rep('c', length(feed_info$field))
   feed_info$coltype[transfers$field %in% c('feed_start_date', 'feed_end_date')] <- 'D'

--- a/R/spec.R
+++ b/R/spec.R
@@ -120,7 +120,7 @@ get_gtfs_meta <- function() {
   transfers$field_spec <- c('req', 'req', 'req', 'opt')
   names(transfers$field_spec) <- transfers$field
   transfers$coltype <- rep('c', length(transfers$field))
-  transfers$coltype[transfers$field %in% c('exception_type')] <- 'i'
+  transfers$coltype[transfers$field %in% c('exception_type', 'min_transfer_time')] <- 'i'
   transfers$file_spec <- 'opt'
   
   # feed_info

--- a/tests/testthat/test-import-gtfs.R
+++ b/tests/testthat/test-import-gtfs.R
@@ -26,7 +26,7 @@ test_that('Downloading a zip file from a gtfs_example_url returns a file', {
     skip("no internet, skipping")
   }
   else {  
-  zip <- tidytransit:::download_from_url(gtfs_example_url)
+  zip <- tidytransit:::download_from_url(gtfs_example_url, quiet = T)
 
   expect_true(file.exists(zip))
   }

--- a/tests/testthat/test-import-gtfs.R
+++ b/tests/testthat/test-import-gtfs.R
@@ -85,8 +85,8 @@ test_that('the read_gtfs function fails gracefully on bad urls', {
     bad_url <- "https://developers.google.com/transit/gtfs/examples/sample-feed-bad.zip"
   
     # non-specified path
-    expect_error(read_gtfs(not_zip, quiet=TRUE))
-    expect_error(read_gtfs(bad_url, quiet=TRUE)) # not zip file warning
+    expect_error(tidytransit::read_gtfs(not_zip, quiet=TRUE))
+    expect_error(tidytransit::read_gtfs(bad_url, quiet=TRUE)) # not zip file warning
   }
   
 })

--- a/tests/testthat/test-import-gtfs.R
+++ b/tests/testthat/test-import-gtfs.R
@@ -1,10 +1,9 @@
 context('Import and Validation')
 
-gtfs_example_url <- "https://developers.google.com/transit/gtfs/examples/sample-feed.zip"
+gtfs_example_url <- "https://github.com/r-transit/tidytransit/raw/master/inst/extdata/sample-feed-fixed.zip"
 local_gtfs_path <- system.file("extdata", "google_transit_nyc_subway.zip", package = "tidytransit")
 
 working <- function() {
-  skip_on_cran()
   connecting <- function(gtfs_example_url) {
     r <- base::try(httr::GET(gtfs_example_url, httr::timeout(5)))
     if(!assertthat::is.error(r)) r$status_code == 200 else FALSE
@@ -23,7 +22,7 @@ test_that('read_gtfs() imports a local file to a list of dataframes and doesnt d
 
 test_that('Downloading a zip file from a gtfs_example_url returns a file', {
   skip_on_cran()
-  if(working()==FALSE){
+  if(!working()){
     skip("no internet, skipping")
   }
   else {  
@@ -42,7 +41,7 @@ test_that('import-bad paths throw good errors', {
 # parse_gtfs()
 test_that('import-empty txt files are not imported and non-empty ones are imported', {
   skip_on_cran()
-  if(working()==FALSE){
+  if(!working()){
     skip("no internet, skipping")
   }
   else {
@@ -64,7 +63,7 @@ test_that('import-empty txt files are not imported and non-empty ones are import
 #read_gtfs()
 test_that('the read_gtfs function works', {
   skip_on_cran()
-  if(working()==FALSE){
+  if(!working()){
       skip("no internet, skipping")
   }
   else {
@@ -78,7 +77,7 @@ test_that('the read_gtfs function works', {
 #read_gtfs()
 test_that('the read_gtfs function fails gracefully on bad urls', {
   skip_on_cran()
-  if(working()==FALSE){
+  if(!working()){
       skip("no internet, skipping")
   }
   else {

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -1,7 +1,7 @@
 context('Import metadata from transitfeeds')
 
 working <- function() {
-  url <- "https://developers.google.com/transit/gtfs/examples/sample-feed.zip"
+  url <- "https://github.com/r-transit/tidytransit/raw/master/inst/extdata/sample-feed-fixed.zip"
   connecting <- function(url) {
     r <- base::try(httr::GET(url, httr::timeout(5)))
     if(!assertthat::is.error(r)) r$status_code == 200 else FALSE
@@ -9,11 +9,10 @@ working <- function() {
   connecting(url)
 }
 
-#read_gtfs()
 test_that('the metadata from transitfeeds is a data frame that is not empty', {
   skip_on_cran()
   tfkey <- Sys.getenv('TRANSITFEED_API')
-  if(working()==FALSE){
+  if(!working()){
     skip("no internet, skipping")
   }
   else if (identical(tfkey, "")) {


### PR DESCRIPTION
With this PR, the test files use the fixed sample feed within the repository (see #37). The examples also refer to that feed. Plus, I re-added min_transfer_time as integer (lost pr #31) and cleaned up spec.R by removing service_name and exception_type (for transfers).