### PR TITLE
Try url then local path

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -35,7 +35,7 @@ read_gtfs <- function(path, local = FALSE,
                       geometry=FALSE,
                       frequency=FALSE) {
   # download zip file
-  if (!local) {
+  if (!local && valid_url(path)) {
     path <- download_from_url(url = path, quiet = quiet)
     if (is.null(path)) { 
       return() 
@@ -120,13 +120,7 @@ download_from_url <- function(url,
       stop('Please input a single url.')
     }
   }
-  
-  # check if url links to a zip file
-  if(!valid_url(url)) {
-    stop1 <- sprintf("Link '%s' is invalid; failed to connect.", url)
-    stop(stop1)
-  }
-  
+
   r <- httr::GET(url)
   
   # Get gtfs zip if url can be reach

--- a/R/import.R
+++ b/R/import.R
@@ -201,6 +201,10 @@ unzip_file <- function(zipfile,
     return(NULL)
   }
 
+  if(!file.exists(f) && !dir.exists(f)) {
+    stop(paste0('"', f, '": No such file or directory'))
+  }
+  
   f <- normalizePath(f)
 
   if(tools::file_ext(f) != "zip") {

--- a/tests/testthat/test-import-gtfs.R
+++ b/tests/testthat/test-import-gtfs.R
@@ -110,7 +110,7 @@ test_that("Some minimal validation is performed and returned", {
 
 test_that("unknown local file throws meaningful error", {
   tidytransit::read_gtfs(local_gtfs_path)
-  expect_warning(expect_error(tidytransit::read_gtfs("/Users/wrong.zip")))
+  expect_error(tidytransit::read_gtfs("/Users/wrong.zip"))
 })
 
 

--- a/tests/testthat/test-import-gtfs.R
+++ b/tests/testthat/test-import-gtfs.R
@@ -108,4 +108,9 @@ test_that("Some minimal validation is performed and returned", {
   }
 })
 
+test_that("unknown local file throws meaningful error", {
+  tidytransit::read_gtfs(local_gtfs_path)
+  expect_warning(expect_error(tidytransit::read_gtfs("/Users/wrong.zip")))
+})
+
 


### PR DESCRIPTION
This PR slightly changes how local files are read. I often download feeds outside of R and I always found `gtfs <- read_gtfs("/path/to/feed.zip", T)` inconvenient. So I'd suggest that read_gtfs checks if the path is a url and then proceeds to download. If not, no error is thrown and the path is considered a local path. The `local = FALSE` default parameter still exists and read_gtfs shouldn't behave differently for current users. Even though I'd say we could get rid of the param quite easily.
