### PR TITLE
Use zipr() instead of zip() in write_gtfs

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -83,5 +83,5 @@ write_gtfs <- function(gtfs_obj, zipfile, compression_level = 9) {
     readr::write_csv(dd, paste0(tmp, "/", filename, ".txt"), )
   }
   filelist = paste0(tmp, "/", filenames, ".txt")
-  zip::zip(zipfile, filelist, recurse = F, compression_level = compression_level)
+  zip::zipr(zipfile, filelist, recurse = F, compression_level = compression_level)
 }


### PR DESCRIPTION
Deprecation message: "zip::zip() is deprecated, please use zip::zipr() instead". Also fixes some bugs with write_gtfs on my computer, don't know how widespread these are.