### PR TITLE
travel_time() returns tibble by default

### DIFF
--- a/R/raptor.R
+++ b/R/raptor.R
@@ -34,8 +34,8 @@
 #'             journey with shortest travel time is returned. With `earliest` the 
 #'             journey arriving at a stop the earliest is returned.
 #'
-#' @return By default a table with travel times to all stop_ids reachable from 
-#'         `from_stop_ids` and their corresponding journey departure and arrival times.
+#' @return A data.table with travel times to all stop_ids reachable from `from_stop_ids` 
+#'         and their corresponding journey departure and arrival times.
 #'
 #' @import data.table
 #' @export
@@ -230,6 +230,8 @@ raptor = function(stop_times,
 #' @param max_departure_time Either set this parameter or `departure_time_range`. Only 
 #'                           departures before `max_departure_time` are used. Accepts 
 #'                           "HH:MM:SS" or seconds as numerical value.
+#' @param return_DT travel_times() returns a data.table if TRUE. Default is FALSE which returns 
+#'                  a tibble/tbl_df.
 #'                           
 #' @return A table with travel times to all stops reachable from `from_stop_name` and their
 #'         corresponding journey departure and arrival times.
@@ -257,7 +259,8 @@ travel_times = function(filtered_stop_times,
                         from_stop_name,
                         departure_time_range = 3600,
                         max_transfers = NULL,
-                        max_departure_time = NULL) {
+                        max_departure_time = NULL,
+                        return_DT = FALSE) {
   travel_time <- min_arrival_time <- journey_departure_time <- NULL
   if("gtfs" %in% class(filtered_stop_times)) {
     stop("Travel times cannot be calculated on a gtfs object. Use filter_stop_times.")
@@ -301,6 +304,11 @@ travel_times = function(filtered_stop_times,
   
   rptr_names <- rptr_names[,c("stop_name", "travel_time", "journey_departure_time",
                               "min_arrival_time", "transfers", "stop_id", "stop_lon", "stop_lat")]
+  
+  if(!return_DT) {
+    rptr_names <- tibble::as_tibble(rptr_names)
+  }
+  
   return(rptr_names)
 }
 

--- a/man/raptor.Rd
+++ b/man/raptor.Rd
@@ -29,8 +29,8 @@ journey with shortest travel time is returned. With \code{earliest} the
 journey arriving at a stop the earliest is returned.}
 }
 \value{
-By default a table with travel times to all stop_ids reachable from
-\code{from_stop_ids} and their corresponding journey departure and arrival times.
+A data.table with travel times to all stop_ids reachable from \code{from_stop_ids}
+and their corresponding journey departure and arrival times.
 }
 \description{
 \code{raptor} finds the minimal travel time and/or earliest arrival time for all

--- a/man/travel_times.Rd
+++ b/man/travel_times.Rd
@@ -6,7 +6,7 @@
 \usage{
 travel_times(filtered_stop_times, from_stop_name,
   departure_time_range = 3600, max_transfers = NULL,
-  max_departure_time = NULL)
+  max_departure_time = NULL, return_DT = FALSE)
 }
 \arguments{
 \item{filtered_stop_times}{stop_times data.table (with transfers and stops tables as
@@ -25,6 +25,9 @@ journeys.}
 \item{max_departure_time}{Either set this parameter or \code{departure_time_range}. Only
 departures before \code{max_departure_time} are used. Accepts
 "HH:MM:SS" or seconds as numerical value.}
+
+\item{return_DT}{travel_times() returns a data.table if TRUE. Default is FALSE which returns
+a tibble/tbl_df.}
 }
 \value{
 A table with travel times to all stops reachable from \code{from_stop_name} and their

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -18,14 +18,15 @@ test_that("travel times wrapper function", {
     from_stop_name = "One", 
     departure_time_range = 3600)
   expect_equal(nrow(tt), length(unique(g$stops$stop_name)))
-  expect_equal(tt[stop_name == "One", travel_time], 0)
-  expect_equal(tt[stop_name == "Two", travel_time], 4*60)
-  expect_equal(tt[stop_name == "Three", travel_time], (18-12)*60)
-  expect_equal(tt[stop_name == "Four", travel_time], (37-17)*60)
-  expect_equal(tt[stop_name == "Five", travel_time], (15-10)*60)
-  expect_equal(tt[stop_name == "Six", travel_time], (20-10)*60)
-  expect_equal(tt[stop_name == "Seven", travel_time], (25-10)*60)
-  expect_equal(tt[stop_name == "Eight", travel_time], (24-12)*60)
+  expect_equal(tt %>% dplyr::filter(stop_name == "One") %>% dplyr::pull(travel_time), 0)
+  expect_equal(tt$travel_time[which(tt$stop_name == "One")], 0)
+  expect_equal(tt$travel_time[which(tt$stop_name == "Two")], 4*60)
+  expect_equal(tt$travel_time[which(tt$stop_name == "Three")], (18-12)*60)
+  expect_equal(tt$travel_time[which(tt$stop_name == "Four")], (37-17)*60)
+  expect_equal(tt$travel_time[which(tt$stop_name == "Five")], (15-10)*60)
+  expect_equal(tt$travel_time[which(tt$stop_name == "Six")], (20-10)*60)
+  expect_equal(tt$travel_time[which(tt$stop_name == "Seven")], (25-10)*60)
+  expect_equal(tt$travel_time[which(tt$stop_name == "Eight")], (24-12)*60)
 })
 
 test_that("travel_time works with different params", {
@@ -176,7 +177,17 @@ test_that("transfers for travel_times", {
   tt = travel_times(
     filtered_stop_times = fst, 
     from_stop_name = "One", 
-    departure_time_range = 3600)
-  expect_equal(tt[order(stop_id)]$transfers, 
-    c(0, 0, 0, 1, 0, 0, 1, 0))
+    departure_time_range = 3600) %>% 
+    arrange(stop_id)
+  expect_equal(tt$transfers, 
+               c(0, 0, 0, 1, 0, 0, 1, 0))
+})
+
+test_that("travel_times return type", {
+  fst = filter_stop_times(g, "2018-10-01", 0, 24*3600)
+  expect_s3_class(travel_times(fst, "One", return_DT = TRUE), "data.frame")
+  expect_s3_class(travel_times(fst, "One", return_DT = FALSE), "data.frame")
+  expect_s3_class(travel_times(fst, "One"), "tbl_df")
+  expect_s3_class(travel_times(fst, "One", return_DT = FALSE), "tbl_df")
+  expect_s3_class(travel_times(fst, "One", return_DT = TRUE), "data.table")
 })


### PR DESCRIPTION
Closes #112 

`raptor` is the "lower level" implementation and still returns data.tables