### PR TITLE
Earlier transfers from from_stops

### DIFF
--- a/R/raptor.R
+++ b/R/raptor.R
@@ -369,15 +369,14 @@ travel_times = function(filtered_stop_times,
 #' @param max_arrival_time The latest arrival time. Can be given as "HH:MM:SS", 
 #'                         hms object or numeric value in seconds
 #' 
-#' @seealso This function creates filtered `stop_times` for [travel_times()] and [raptor()].
+#' This function creates filtered `stop_times` for [travel_times()] and [raptor()]. If you
+#' want to filter a feed multiple times it is faster to precalculate date_service_table with
+#' [set_date_service_table()].
 #'                         
 #' @export                
 #' @examples 
 #' feed_path <- system.file("extdata", "sample-feed-fixed.zip", package = "tidytransit")
 #' g <- read_gtfs(feed_path)
-#' 
-#' # Consider precalculating date_service_table for the feed.
-#' g <- set_date_service_table(g)
 #' 
 #' # filter the sample feed
 #' stop_times <- filter_stop_times(g, "2007-01-06", "06:00:00", "08:00:00")
@@ -403,8 +402,9 @@ filter_stop_times = function(gtfs_obj,
     stop("max_arrival_time is before min_departure_time")
   }
   
-  # trips runnin on day
+  # trips running on day
   if(!feed_contains(gtfs_obj, "date_service_table")) {
+    message("Consider using set_date_service_table beforehand if you filter this feed multiple times")
     gtfs_obj <- set_date_service_table(gtfs_obj)
   }
   service_ids = filter(gtfs_obj$.$date_service_table, date == extract_date)

--- a/R/raptor.R
+++ b/R/raptor.R
@@ -76,43 +76,79 @@ raptor = function(stop_times,
   from_stop_id <- departure_time_num <- marked <- journey_departure_time <- journey_departure_stop_id <- NULL
   wait_time_to_departure <- marked_departure_time_num <- arrival_time_num <- min_transfer_time <- NULL
   to_stop_id <- travel_time <- min_arrival_time <- NULL
+  
+  # check and params ####
   # stop ids need to be a character vector
   # use data.table for faster manipulation
   stop_times_dt <- setup_stop_times(stop_times)
   transfers_dt <- setup_transfers(transfers)
   if(is.data.frame(from_stop_ids)) { from_stop_ids <- from_stop_ids[[1]] }
 
+  nonexistent_stop_ids = setdiff(from_stop_ids, c(stop_times_dt$stop_id, transfers_dt$from_stop_id, transfers_dt$to_stop_id))
+  if(length(nonexistent_stop_ids) > 0) {
+    from_stop_ids <- setdiff(from_stop_ids, nonexistent_stop_ids)
+    if(length(from_stop_ids) == 0) {
+      warning("Stop not found in stop_times or transfers: ", paste(nonexistent_stop_ids, collapse = ", "))
+      empty_dt = data.table(stop_id = character(0), travel_time = numeric(0), journey_departure_stop_id = character(0),
+        journey_departure_time = numeric(0),min_arrival_time = character(0), transfers = numeric(0))
+      return(empty_dt)
+    }
+  }
   if(is.null(keep) || 
      !(keep %in% c("shortest", "earliest", "all"))) {
     stop(paste0(keep, " is not a supported optimization type, all times are returned"))
   }
-  
-  if(all(!(from_stop_ids %in% stop_times$stop_id))) {
-    warning(paste0("No departures from ", paste0(from_stop_ids, collapse = ", ")))
-    return(data.table(stop_id = from_stop_ids, min_arrival_time = 0, journey_departure_time = 0))
-  }
-  
-  # setup work data frame "rptr"
-  rptr_colnames = c("stop_id", "marked", "min_arrival_time", "journey_departure_time", "journey_departure_stop_id", "transfers")
-  
-  # get earliest departure time for from_stop_ids and set them as journey start times
-  rptr = stop_times_dt[stop_id %in% from_stop_ids]
   if(!is.numeric(departure_time_range)) {
     stop("departure_time_range is not numeric. Needs to be the time range in seconds after the first departure of stop_times")
   }
   if(departure_time_range < 1) {
     stop("departure_time_range is less than 1")
   }
-  max_departure_time = min(stop_times_dt$departure_time_num) + departure_time_range
-  rptr <- rptr[departure_time_num <= max_departure_time]
+  min_departure_time = min(stop_times_dt$departure_time_num)
+  max_departure_time = min_departure_time + departure_time_range
+  
+  # set up arrivals at from_stops ####
+  
+  # find stops reachable by transfer from from_stops
+  transfer_stops = data.frame() # only needed for nrow below
+  if(!is.null(transfers_dt)) {
+    transfer_stops <- transfers_dt[from_stop_id %in% from_stop_ids]
+  }
+  
+  # init_stops contains from_stops and stops reachable by transfer
+  rptr_colnames = c("stop_id", "marked", "min_arrival_time", "journey_departure_time", "journey_departure_stop_id", "transfers")
+  
+  init_stops = data.table(
+    stop_id = c(from_stop_ids, transfer_stops$to_stop_id),
+    marked = F,
+    min_arrival_time = c(rep(min_departure_time, length(from_stop_ids)), 
+                         min_departure_time+transfer_stops$min_transfer_time),
+    journey_departure_time = rep(min_departure_time, 
+                                 length(from_stop_ids)+nrow(transfer_stops)),
+    journey_departure_stop_id = c(from_stop_ids, transfer_stops$from_stop_id),
+    transfers = c(rep(0, length(from_stop_ids)), rep(1, nrow(transfer_stops)))
+  )
 
-  # setup columns
-  rptr[, marked := TRUE]
-  rptr[, min_arrival_time := rptr$departure_time_num - 1]
-  rptr[, journey_departure_time := departure_time_num]
-  rptr[, journey_departure_stop_id := stop_id]
-  rptr[, transfers := 0]
+  # mark all departures from init_stops ####
+  init_departures = stop_times_dt[init_stops, on = "stop_id"]
+  init_departures[, journey_departure_time := departure_time_num]
+  init_departures <- init_departures[!is.na(journey_departure_time)]
+  init_departures[, min_arrival_time := journey_departure_time ]
+  init_departures[, journey_departure_stop_id := stop_id]
+  init_departures[, marked := TRUE]
+  init_departures[, transfers := 0]
+  init_departures <- init_departures[, rptr_colnames, with = F]
+  
+  # rptr: work data frame ####
+  rptr <- rbind(init_stops, init_departures)
   rptr <- rptr[, rptr_colnames, with = F]
+  rptr <- distinct(rptr)
+
+  # raptor loop works with departure > arrival 
+  rptr[, min_arrival_time := min_arrival_time-1]
+  
+  # only keep departures within time range for initial loop
+  rptr <- rptr[journey_departure_time <= max_departure_time]
   
   # raptor loop ####
   k = 0
@@ -131,6 +167,7 @@ raptor = function(stop_times,
     # use each departure/trip once (for the closest journey_departure_time)
     setorder(departures_marked, wait_time_to_departure)
     departures_marked <- departures_marked[, .SD[1], by=c("stop_id", "trip_id")]
+    
     # get trips from marked departures
     setorder(departures_marked, departure_time_num)
     trips_marked <- departures_marked[, .SD[1], by=c("trip_id", "journey_departure_time")]
@@ -187,14 +224,20 @@ raptor = function(stop_times,
     # slightly faster than:
     # 	rptr[, rank := seq_len(.N), by = c("stop_id", "journey_departure_time")]
     # 	rptr <- rptr[.rank1, on = "rank"]
-   
+    
     # iteration is finished, the remaining marked stops have been improved
     k <- k+1
     if(!is.null(max_transfers) && k > max_transfers) { break }
   }
   
+  # create results ####
+  
   # fix min_arrival_times of from_stops
-  rptr[stop_id %in% from_stop_ids, min_arrival_time := min_arrival_time + 1]
+  rptr[stop_id %in% init_stops$stop_id, min_arrival_time := min_arrival_time + 1]
+
+  # only keep one arrival (earliest) for initial stops
+  rptr <- rptr[!stop_id %in% init_stops$stop_id]
+  rptr <- rbind(init_stops, rptr)
   
   # calculate travel_time
   rptr[,travel_time := min_arrival_time - journey_departure_time]
@@ -208,8 +251,9 @@ raptor = function(stop_times,
     rptr <- rptr[, .SD[1], by="stop_id"]
   }
   
-  # return result table
-  rptr <- rptr[,c("stop_id", "travel_time", "journey_departure_stop_id", "journey_departure_time", "min_arrival_time", "transfers")]
+  # build result table
+  rptr <- rptr[, c("stop_id", "travel_time", "journey_departure_stop_id", 
+                   "journey_departure_time", "min_arrival_time", "transfers")]
   return(rptr)
 }
 

--- a/man/filter_stop_times.Rd
+++ b/man/filter_stop_times.Rd
@@ -16,7 +16,11 @@ filter_stop_times(gtfs_obj, extract_date, min_departure_time,
 hms object or numeric value in seconds.}
 
 \item{max_arrival_time}{The latest arrival time. Can be given as "HH:MM:SS",
-hms object or numeric value in seconds}
+hms object or numeric value in seconds
+
+This function creates filtered \code{stop_times} for \code{\link[=travel_times]{travel_times()}} and \code{\link[=raptor]{raptor()}}. If you
+want to filter a feed multiple times it is faster to precalculate date_service_table with
+\code{\link[=set_date_service_table]{set_date_service_table()}}.}
 }
 \description{
 Filter a \code{stop_times} table for a given date and timespan.
@@ -25,12 +29,6 @@ Filter a \code{stop_times} table for a given date and timespan.
 feed_path <- system.file("extdata", "sample-feed-fixed.zip", package = "tidytransit")
 g <- read_gtfs(feed_path)
 
-# Consider precalculating date_service_table for the feed.
-g <- set_date_service_table(g)
-
 # filter the sample feed
 stop_times <- filter_stop_times(g, "2007-01-06", "06:00:00", "08:00:00")
-}
-\seealso{
-This function creates filtered \code{stop_times} for \code{\link[=travel_times]{travel_times()}} and \code{\link[=raptor]{raptor()}}.
 }

--- a/man/get_feedlist.Rd
+++ b/man/get_feedlist.Rd
@@ -14,7 +14,7 @@ Get list of all available feeds from transitfeeds API
 }
 \examples{
 \donttest{
-feedlist_df <- get_feedlist() 
+feedlist_df <- get_feedlist()
 }
 }
 \seealso{

--- a/man/raptor.Rd
+++ b/man/raptor.Rd
@@ -82,4 +82,6 @@ hist(shortest_travel_times$travel_time, breaks = 360)
 }
 \seealso{
 \code{\link[=travel_times]{travel_times()}}
+
+travel_times, filter_stop_times
 }

--- a/man/read_gtfs.Rd
+++ b/man/read_gtfs.Rd
@@ -33,8 +33,8 @@ sample_gtfs <- read_gtfs(u1)
 attach(sample_gtfs)
 #list routes by the number of stops they have
 routes \%>\% inner_join(trips, by="route_id") \%>\%
-  inner_join(stop_times) \%>\% 
-    inner_join(stops, by="stop_id") \%>\% 
+  inner_join(stop_times) \%>\%
+    inner_join(stops, by="stop_id") \%>\%
       group_by(route_long_name) \%>\%
         summarise(stop_count=n_distinct(stop_id)) \%>\%
           arrange(desc(stop_count))

--- a/man/travel_times.Rd
+++ b/man/travel_times.Rd
@@ -62,6 +62,3 @@ library(ggplot2)
 ggplot(tts) + geom_point(aes(x=stop_lon, y=stop_lat, color = travel_time))
 }
 }
-\seealso{
-filter_stop_times, raptor
-}

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -6,7 +6,7 @@ g <- set_hms_times(g)
 from_stop_ids <- c("stop1a", "stop1b")
 
 stop_times = g$stop_times
-stop_times_0709 = dplyr::filter(g$stop_times, departure_time_hms >= 7*3600+09*60)
+stop_times_0709 = dplyr::filter(g$stop_times, departure_time_hms >= 7*3600+10*60)
 stop_times_0711 = dplyr::filter(g$stop_times, departure_time_hms >= 7*3600+11*60)
 stop_times_0715 = dplyr::filter(g$stop_times, departure_time_hms >= 7*3600+15*60)
 transfers = g$transfers
@@ -71,28 +71,28 @@ test_that("raptor travel times", {
 })
 
 test_that("ea and tt return the same result for one departure", {
-  travel_time = raptor(stop_times, transfers, from_stop_ids,
+  shortest = raptor(stop_times, transfers, from_stop_ids,
                        departure_time_range = 60,
-                       keep = "shortest")
-  travel_time <- travel_time[order(stop_id), travel_time]
+                       keep = "shortest")[order(stop_id)]
+  shortest_tt <- shortest$travel_time
   
   earliest_arrival = raptor(stop_times, transfers, from_stop_ids,
                             departure_time_range = 60,
-                            keep = "earliest")
-  earliest_arrival_tt <- earliest_arrival[order(stop_id), min_arrival_time]
-  earliest_arrival_tt <- earliest_arrival_tt - 7*3600
-  
-  expect_equal(travel_time, earliest_arrival_tt)
+                            keep = "earliest")[order(stop_id)]
+  earliest_arrival_tt <- earliest_arrival$min_arrival_time - 7*3600
+
+  expect_equal(shortest_tt, earliest_arrival_tt)
 })
 
 test_that("travel_time with one stop and reduced departure_time_range", {
   r = raptor(stop_times_0709, transfers, "stop1a",
-             departure_time_range = 120,
+             departure_time_range = 30,
              keep = "shortest")[order(stop_id)]
-  actual <- r[order(stop_id), travel_time]
+  actual <- r$travel_time
   
   expected = c(
     00*60 + 00, # stop1a 00:00:00
+    00*60 + 10, # stop1b 00:00:00
     18*60 + 00, # stop3a 00:18:00
     18*60 + 10, # stop3b 00:18:10
     27*60 + 00, # stop4  00:27:00
@@ -116,7 +116,7 @@ test_that("parameters are checked", {
   expect_error(raptor(st, tr, c("stop1a", "stop1b"), keep = "NULL"))
   
   # non-existent stop_id
-  expect_warning(raptor(st, tr, "stop1"))
+  expect_warning(raptor(st, tr, "stop99"))
   expect_warning(raptor(st, tr, 42))
   
   # time range type
@@ -127,14 +127,14 @@ test_that("parameters are checked", {
   expect_error(raptor(st, tr, "stop5", departure_time_range = hms::hms(900)))
   
   # empty results
-  expect_equal(nrow(raptor(st, tr, "stop5", departure_time_range = 60)), 0)
+  expect_equal(nrow(raptor(st, tr, "stop5", departure_time_range = 60)), 1)
 })
 
 test_that("earliest arrival times", {
   r = raptor(stop_times, transfers, "stop2", keep = "earliest")
   actual = r[order(stop_id), min_arrival_time]
   expected = c(
-    7*3600 + 05*60 + 00, # stop2  07:05:00 departure time
+    7*3600 + 00*60 + 00, # stop2  07:05:00 departure time
     7*3600 + 11*60 + 00, # stop3a 07:11:00
     7*3600 + 11*60 + 10, # stop3b 07:11:10
     7*3600 + 37*60 + 00, # stop4  07:37:00
@@ -149,7 +149,7 @@ test_that("earliest arrival time without transfers", {
   actual = r[order(stop_id), min_arrival_time]
   expected = c(
     7*3600 + 00*60, # stop1a 07:00
-    7*3600 + 12*60, # stop1b 07:12
+    7*3600 + 00*60, # stop1b 07:12
     7*3600 + 04*60, # stop2  07:04
     7*3600 + 11*60, # stop3a 07:11
     7*3600 + 18*60, # stop3b 07:18
@@ -190,4 +190,24 @@ test_that("travel_times return type", {
   expect_s3_class(travel_times(fst, "One"), "tbl_df")
   expect_s3_class(travel_times(fst, "One", return_DT = FALSE), "tbl_df")
   expect_s3_class(travel_times(fst, "One", return_DT = TRUE), "data.table")
+})
+
+test_that("travel_times from stop with departures from transfer stops", {
+  g2 = g
+  g2$stops[nrow(g2$stops)+1,] <- c("stop0", "Zero", 46.9596, 7.39071, NA, 0)
+  g2$transfers[nrow(g2$transfers)+1,] <- c("stop0", "stop1a", "2", 1)
+  g2$transfers$min_transfer_time <- as.numeric(g2$transfers$min_transfer_time)
+  fst2 = filter_stop_times(g2, "2018-10-01", 0, 24*3600)
+  expect_equal(nrow(travel_times(fst2, "Zero")), 9)
+})
+
+test_that("raptor from stop without departures", {
+  expect_warning(raptor(stop_times_0711, transfers, "stop2"))
+  expect_equal(nrow(raptor(stop_times_0711, transfers, "stop4")), 1)
+})
+
+test_that("empty return data.table has the same columns as correct", {
+  r1 = suppressWarnings(raptor(stop_times_0711, transfers, "stop2"))
+  r2 = raptor(stop_times_0711, transfers, "stop3a")
+  expect_equal(colnames(r1), colnames(r2))
 })


### PR DESCRIPTION
With this PR, `raptor` considers transfers from `from_stop_id` on the minimal departure time instead of the time of the first actual departure in stop_times. Everything else, especially departure time range behavior, stays the same.