### PR TITLE
Travel times for incoming journeys

### DIFF
--- a/R/raptor.R
+++ b/R/raptor.R
@@ -78,6 +78,12 @@ raptor = function(stop_times,
   wait_time_to_departure <- marked_departure_time_num <- arrival_time_num <- min_transfer_time <- NULL
   to_stop_id <- travel_time <- min_arrival_time <- NULL
 
+  if(!is.character(from_stop_ids) && !is.null(from_stop_ids)) {
+    stop("from_stop_ids must be a character vector (or NULL)")
+  } 
+  if(!is.character(to_stop_ids) && !is.null(to_stop_ids)) {
+    stop("to_stop_ids must be a character vector (or NULL)")
+  }
   rev_stop_times = FALSE
   if(is.null(from_stop_ids) & is.null(to_stop_ids)) {
     stop("Both from_stop_ids and to_stop_ids are NULL")

--- a/R/raptor.R
+++ b/R/raptor.R
@@ -69,13 +69,18 @@
 #' }
 raptor = function(stop_times,
                   transfers,
-                  from_stop_ids,
+                  from_stop_ids = NULL,
+                  to_stop_ids = NULL,
                   departure_time_range = 3600,
                   max_transfers = NULL,
                   keep = "all") {
   from_stop_id <- departure_time_num <- marked <- journey_departure_time <- journey_departure_stop_id <- NULL
   wait_time_to_departure <- marked_departure_time_num <- arrival_time_num <- min_transfer_time <- NULL
   to_stop_id <- travel_time <- min_arrival_time <- NULL
+
+  if(is.null(from_stop_ids) & is.null(to_stop_ids)) {
+    stop("Both from_stop_ids and to_stop_ids are NULL")
+  }
   
   # check and params ####
   # stop ids need to be a character vector

--- a/R/raptor.R
+++ b/R/raptor.R
@@ -118,12 +118,17 @@ raptor = function(stop_times,
   }
   min_departure_time = min(stop_times_dt$departure_time_num)
   max_departure_time = min_departure_time + departure_time_range
+  if(is.null(max_transfers)) {
+    max_transfers <- 999999
+  } else if(max_transfers < 0) {
+    stop("max_transfers is less than 0")
+  }
   
   # set up arrivals at from_stops ####
   
   # find stops reachable by transfer from from_stops
   transfer_stops = data.frame() # only needed for nrow below
-  if(!is.null(transfers_dt)) {
+  if(!is.null(transfers_dt) && max_transfers > 0) {
     transfer_stops <- transfers_dt[from_stop_id %in% from_stop_ids]
   }
   
@@ -206,7 +211,7 @@ raptor = function(stop_times,
     arrival_candidates <- arrival_candidates[, rptr_colnames, with = F]
     
     # Find all transfers for arrival candidates
-    if(!is.null(transfers_dt)) {
+    if(!is.null(transfers_dt) && (k+1) <= max_transfers) {
       transfer_candidates = merge(
         arrival_candidates,
         transfers_dt,
@@ -239,7 +244,7 @@ raptor = function(stop_times,
     
     # iteration is finished, the remaining marked stops have been improved
     k <- k+1
-    if(!is.null(max_transfers) && k > max_transfers) { break }
+    if(k > max_transfers) { break }
   }
   
   # create results ####

--- a/R/raptor.R
+++ b/R/raptor.R
@@ -1,19 +1,19 @@
 #' Calculate travel times from one stop to all reachable stops
 #' 
-#' `raptor` finds the minimal travel time and/or earliest arrival time for all 
+#' `raptor` finds the minimal travel time, earliest or latest arrival time for all 
 #' stops in `stop_times` with journeys departing from `stop_ids` within 
 #' `time_range`.
 #' 
 #' With a modified [Round-Based Public Transit Routing Algorithm](https://www.microsoft.com/en-us/research/publication/round-based-public-transit-routing) 
-#' (RAPTOR) using data.table earliest arrival times for all stops are calculated. If two 
+#' (RAPTOR) using data.table, earliest arrival times for all stops are calculated. If two 
 #' journeys arrive at the same time, the one with the later departure time and thus shorter 
 #' travel time is kept. By default, all journeys departing within `time_range` that arrive 
 #' at a stop are returned in a table. If you want all journeys _arriving_ at stop_ids within
 #' the specified time range, set `arrival` to TRUE.
 #' 
-#' Journeys are defined by a "from" and "to" stop_id, a 
-#' departure, arrival and travel time. Note that the exact journeys (with each intermediate 
-#' stop and route id for example) is _not_ returned.
+#' Journeys are defined by a "from" and "to" stop_id, a departure, arrival and travel time. 
+#' Note that the exact journeys (with each intermediate stop and route ids for example) is 
+#' _not_ returned.
 #' 
 #' For most cases, `stop_times` needs to be filtered, as it should only contain trips 
 #' happening on a single day and departures later than a given journey start time, see 
@@ -30,22 +30,21 @@
 #'                TRUE, all journeys _end_ at `stop_ids`.
 #' @param time_range Departure or arrival time range in seconds. All departures from the 
 #'                   first departure of stop_times (not necessarily from stop_id in 
-#'                   `stop_ids`) within `time_range` (in seconds) are considered. If 
-#'                   `arrival` is TRUE, all arrivals within `time_range` before the latest 
-#'                   arrival of stop_times are considered.
+#'                   `stop_ids`) within `time_range` are considered. If `arrival` is TRUE, 
+#'                   all arrivals within `time_range` before the latest arrival time of 
+#'                   stop_times are considered.
 #' @param max_transfers Maximum number of transfers allowed, no limit (NULL) as default.
-#' @param keep One of c("all", "shortest", "earliest", "latest"). By default `all` journeys arriving 
-#'             at a stop are returned. With `shortest` the journey with shortest travel 
-#'             time is returned. With `earliest` the journey arriving at a stop the earliest 
-#'             is returned, `latest` works accordingly.
+#' @param keep One of c("all", "shortest", "earliest", "latest"). By default, `all` journeys 
+#'             arriving at a stop are returned. With `shortest` the journey with shortest 
+#'             travel time is returned. With `earliest` the journey arriving at a stop the 
+#'             earliest is returned, `latest` works accordingly.
 #'
 #' @return A data.table with journeys (departure, arrival and travel time) to/from all 
 #'         stop_ids reachable by `stop_ids`.
 #'
-#' @seealso [travel_times()] 
+#' @seealso [travel_times()] for an easier access to travel time calculations via stop_names.
 #' 
 #' @import data.table
-#' @seealso travel_times, filter_stop_times
 #' @export
 #' @examples \donttest{
 #' nyc_path <- system.file("extdata", "google_transit_nyc_subway.zip", package = "tidytransit")
@@ -305,20 +304,20 @@ raptor = function(stop_times,
 #' 
 #' @param filtered_stop_times stop_times data.table (with transfers and stops tables as 
 #'                            attributes) created with [filter_stop_times()] where the 
-#'                            deparuture time has been set.
-#' @param stop_name stop name for which travel times should becalculated. A vector with 
+#'                            departure or arrival time has been set.
+#' @param stop_name Stop name for which travel times should be calculated. A vector with 
 #'                  multiple names is accepted.
-#' @param arrival If FALSE (default), all journeys _start_ from `stop_name`. If
-#'                TRUE, all journeys _end_ at `stop_name`.
 #' @param time_range All departures within this range in seconds after the first departure 
 #'                   of `filtered_stop_times` are considered for journeys. If arrival is 
 #'                   TRUE, all journeys arriving within time range before the latest arrival 
 #'                   of `filtered_stop_times` are considered.                   
+#' @param arrival If FALSE (default), all journeys _start_ from `stop_name`. If
+#'                TRUE, all journeys _end_ at `stop_name`.
 #' @param max_transfers The maximimum number of transfers
 #' @param max_departure_time Either set this parameter or `time_range`. Only departures 
 #'                           before `max_departure_time` are used. Accepts "HH:MM:SS" or 
-#'                           seconds as numerical value. Unused if `arrival` is TRUE.
-#' @param return_coords returns stop coordinates as columms. Default is FALSE.                            
+#'                           seconds as a numerical value. Unused if `arrival` is TRUE.
+#' @param return_coords Returns stop coordinates as columms. Default is FALSE.                            
 #' @param return_DT travel_times() returns a data.table if TRUE. Default is FALSE which 
 #'                  returns a tibble/tbl_df.
 #'                           
@@ -426,7 +425,7 @@ travel_times = function(filtered_stop_times,
 #' 
 #' @param gtfs_obj a gtfs feed
 #' @param extract_date date to extract trips from in YYYY-MM-DD format
-#' @param min_departure_time The minimal departure time. Can be given as "HH:MM:SS", 
+#' @param min_departure_time The earliest departure time. Can be given as "HH:MM:SS", 
 #'                           hms object or numeric value in seconds.
 #' @param max_arrival_time The latest arrival time. Can be given as "HH:MM:SS", 
 #'                         hms object or numeric value in seconds
@@ -434,7 +433,7 @@ travel_times = function(filtered_stop_times,
 #' This function creates filtered `stop_times` for [travel_times()] and [raptor()]. If you
 #' want to filter a feed multiple times it is faster to precalculate date_service_table with
 #' [set_date_service_table()].
-#'                         
+#' 
 #' @export                
 #' @examples 
 #' feed_path <- system.file("extdata", "sample-feed-fixed.zip", package = "tidytransit")

--- a/R/raptor.R
+++ b/R/raptor.R
@@ -265,7 +265,7 @@ raptor = function(stop_times,
   if(arrival) {
     max_time = 604800
     arrival_tmp = max_time - rptr$journey_arrival_time
-    rptr[,journey_arrival_time := max_time - journey_departure_time]
+    rptr[,journey_arrival_time := (max_time - journey_departure_time)]
     rptr[,journey_departure_time := arrival_tmp]
     stop_tmp = rptr$to_stop_id
     rptr[,to_stop_id := from_stop_id]
@@ -504,8 +504,9 @@ setup_stop_times = function(stop_times, reverse = FALSE) {
   setnames(x = stop_times, new = "to_stop_id", old = "stop_id")
   if(reverse) {
     max_time = 604800
-    stop_times[, arrival_time_num := (max_time - arrival_time_num)]
-    stop_times[, departure_time_num := (max_time - departure_time_num)]
+    arrival_time_tmp = stop_times$arrival_time_num
+    stop_times[, arrival_time_num := (max_time - departure_time_num)]
+    stop_times[, departure_time_num := (max_time - arrival_time_tmp)]
   }
   if(is.null(key(stop_times)) || "trip_id" != key(stop_times)) {
     setkeyv(stop_times, "trip_id") # faster than key on stop_id

--- a/R/raptor.R
+++ b/R/raptor.R
@@ -34,10 +34,10 @@
 #'                   `arrival` is TRUE, all arrivals within `time_range` before the latest 
 #'                   arrival of stop_times are considered.
 #' @param max_transfers Maximum number of transfers allowed, no limit (NULL) as default.
-#' @param keep One of c("all", "shortest", "earliest"). By default `all` journeys arriving 
+#' @param keep One of c("all", "shortest", "earliest", "latest"). By default `all` journeys arriving 
 #'             at a stop are returned. With `shortest` the journey with shortest travel 
 #'             time is returned. With `earliest` the journey arriving at a stop the earliest 
-#'             is returned.
+#'             is returned, `latest` works accordingly.
 #'
 #' @return A data.table with journeys (departure, arrival and travel time) to/from all 
 #'         stop_ids reachable by `stop_ids`.
@@ -109,8 +109,8 @@ raptor = function(stop_times,
     }
   }
   if(is.null(keep) || 
-     !(keep %in% c("shortest", "earliest", "all"))) {
-    stop(paste0(keep, " is not a supported optimization type, all times are returned"))
+     !(keep %in% c("shortest", "earliest", "all", "latest"))) {
+    stop(paste0(keep, " is not a supported optimization type, use one of: all, shortest, earliest, latest"))
   }
   if(!is.numeric(time_range)) {
     stop("time_range is not numeric. Needs to be the time range in seconds after the first departure of stop_times")
@@ -282,6 +282,9 @@ raptor = function(stop_times,
     rptr <- rptr[, .SD[1], by = keep_by]
   } else if(keep == "earliest") {
     setorder(rptr, journey_arrival_time, travel_time)
+    rptr <- rptr[, .SD[1], by = keep_by]
+  } else if(keep == "latest") {
+    setorder(rptr, -journey_arrival_time, travel_time)
     rptr <- rptr[, .SD[1], by = keep_by]
   }
   

--- a/man/filter_stop_times.Rd
+++ b/man/filter_stop_times.Rd
@@ -12,7 +12,7 @@ filter_stop_times(gtfs_obj, extract_date, min_departure_time,
 
 \item{extract_date}{date to extract trips from in YYYY-MM-DD format}
 
-\item{min_departure_time}{The minimal departure time. Can be given as "HH:MM:SS",
+\item{min_departure_time}{The earliest departure time. Can be given as "HH:MM:SS",
 hms object or numeric value in seconds.}
 
 \item{max_arrival_time}{The latest arrival time. Can be given as "HH:MM:SS",

--- a/man/raptor.Rd
+++ b/man/raptor.Rd
@@ -4,8 +4,8 @@
 \alias{raptor}
 \title{Calculate travel times from one stop to all reachable stops}
 \usage{
-raptor(stop_times, transfers, from_stop_ids, departure_time_range = 3600,
-  max_transfers = NULL, keep = "all")
+raptor(stop_times, transfers, from_stop_ids = NULL, to_stop_ids = NULL,
+  departure_time_range = 3600, max_transfers = NULL, keep = "all")
 }
 \arguments{
 \item{stop_times}{A (prepared) stop_times table from a gtfs feed. Prepared means
@@ -15,7 +15,9 @@ happening on one day. Use \code{\link[=filter_stop_times]{filter_stop_times()}} 
 
 \item{transfers}{Transfers table from a gtfs feed. In general no preparation is needed.}
 
-\item{from_stop_ids}{Atomic char vector with stop_ids from where a journey should start}
+\item{from_stop_ids}{character vector with stop_ids from where journeys should start}
+
+\item{to_stop_ids}{character vector with stop_ids where journeys should end}
 
 \item{departure_time_range}{All departures from the first departure of
 stop_times (not necessarily a from_stop) within
@@ -72,7 +74,7 @@ rptr <- raptor(stop_times, nyc$transfers, walk_times$stop_id, departure_time_ran
                keep = "all")
 
 # add walk times to travel times
-rptr <- left_join(rptr, walk_times, by=c("journey_departure_stop_id" = "stop_id"))
+rptr <- left_join(rptr, walk_times, by=c("from_stop_id" = "stop_id"))
 rptr$travel_time_incl_walk <- rptr$travel_time + rptr$walk_time
 
 # get minimal travel times (with walk times) for all stop_ids 

--- a/man/raptor.Rd
+++ b/man/raptor.Rd
@@ -4,7 +4,7 @@
 \alias{raptor}
 \title{Calculate travel times from one stop to all reachable stops}
 \usage{
-raptor(stop_times, transfers, stop_ids, departure = TRUE,
+raptor(stop_times, transfers, stop_ids, arrival = FALSE,
   time_range = 3600, max_transfers = NULL, keep = "all")
 }
 \arguments{
@@ -15,46 +15,49 @@ happening on one day. Use \code{\link[=filter_stop_times]{filter_stop_times()}} 
 
 \item{transfers}{Transfers table from a gtfs feed. In general no preparation is needed.}
 
-\item{stop_ids}{character vector with stop_ids from where journeys should start}
+\item{stop_ids}{Character vector with stop_ids from where journeys should start (or end)}
 
-\item{departure}{If TRUE (default), all journeys \emph{start} from \code{stop_ids}. If
-FALSE, all journeys \emph{end} at \code{stop_ids}.}
+\item{arrival}{If FALSE (default), all journeys \emph{start} from \code{stop_ids}. If
+TRUE, all journeys \emph{end} at \code{stop_ids}.}
 
-\item{time_range}{All departures from the first departure of stop_times (not necessarily
-from stop_id in \code{stop_ids}) within \code{time_range} (in seconds) are
-considered. If \code{outgoing} is FALSE, all arrivals from}
+\item{time_range}{Departure or arrival time range in seconds. All departures from the
+first departure of stop_times (not necessarily from stop_id in
+\code{stop_ids}) within \code{time_range} (in seconds) are considered. If
+\code{arrival} is TRUE, all arrivals within \code{time_range} before the latest
+arrival of stop_times are considered.}
 
 \item{max_transfers}{Maximum number of transfers allowed, no limit (NULL) as default.}
 
-\item{keep}{One of c("all", "shortest", "earliest"). By default \code{all} journeys
-arriving at a stop are returned. With \code{shortest} the
-journey with shortest travel time is returned. With \code{earliest} the
-journey arriving at a stop the earliest is returned.}
+\item{keep}{One of c("all", "shortest", "earliest"). By default \code{all} journeys arriving
+at a stop are returned. With \code{shortest} the journey with shortest travel
+time is returned. With \code{earliest} the journey arriving at a stop the earliest
+is returned.}
 }
 \value{
-A data.table with travel times to all stop_ids reachable from \code{from_stop_ids}
-and their corresponding journey departure and arrival times.
+A data.table with journeys (departure, arrival and travel time) to/from all
+stop_ids reachable by \code{stop_ids}.
 }
 \description{
 \code{raptor} finds the minimal travel time and/or earliest arrival time for all
-stops in \code{stop_times} with journeys departing from \code{from_stop_ids} within
+stops in \code{stop_times} with journeys departing from \code{stop_ids} within
 \code{time_range}.
 }
 \details{
 With a modified \href{https://www.microsoft.com/en-us/research/publication/round-based-public-transit-routing}{Round-Based Public Transit Routing Algorithm}
 (RAPTOR) using data.table earliest arrival times for all stops are calculated. If two
 journeys arrive at the same time, the one with the later departure time and thus shorter
-travel time is kept. By default, all journeys within \code{time_range} that arrive
-at a stop are returned in a table. Journeys are defined by a departure stop_id, a
+travel time is kept. By default, all journeys departing within \code{time_range} that arrive
+at a stop are returned in a table. If you want all journeys \emph{arriving} at stop_ids within
+the specified time range, set \code{arrival} to TRUE.
+
+Journeys are defined by a "from" and "to" stop_id, a
 departure, arrival and travel time. Note that the exact journeys (with each intermediate
 stop and route id for example) is \emph{not} returned.
 
-For most cases, \code{stop_times} needs to be filtered as it should only contain trips
+For most cases, \code{stop_times} needs to be filtered, as it should only contain trips
 happening on a single day and departures later than a given journey start time, see
-\code{\link[=filter_stop_times]{filter_stop_times()}}.
-
-The algorithm scans all trips until it exceeds \code{max_transfers} or all trips
-in \code{stop_times} have been visited.
+\code{\link[=filter_stop_times]{filter_stop_times()}}. The algorithm scans all trips until it exceeds \code{max_transfers}
+or all trips in \code{stop_times} have been visited.
 }
 \examples{
 \donttest{

--- a/man/raptor.Rd
+++ b/man/raptor.Rd
@@ -22,37 +22,37 @@ TRUE, all journeys \emph{end} at \code{stop_ids}.}
 
 \item{time_range}{Departure or arrival time range in seconds. All departures from the
 first departure of stop_times (not necessarily from stop_id in
-\code{stop_ids}) within \code{time_range} (in seconds) are considered. If
-\code{arrival} is TRUE, all arrivals within \code{time_range} before the latest
-arrival of stop_times are considered.}
+\code{stop_ids}) within \code{time_range} are considered. If \code{arrival} is TRUE,
+all arrivals within \code{time_range} before the latest arrival time of
+stop_times are considered.}
 
 \item{max_transfers}{Maximum number of transfers allowed, no limit (NULL) as default.}
 
-\item{keep}{One of c("all", "shortest", "earliest"). By default \code{all} journeys arriving
-at a stop are returned. With \code{shortest} the journey with shortest travel
-time is returned. With \code{earliest} the journey arriving at a stop the earliest
-is returned.}
+\item{keep}{One of c("all", "shortest", "earliest", "latest"). By default, \code{all} journeys
+arriving at a stop are returned. With \code{shortest} the journey with shortest
+travel time is returned. With \code{earliest} the journey arriving at a stop the
+earliest is returned, \code{latest} works accordingly.}
 }
 \value{
 A data.table with journeys (departure, arrival and travel time) to/from all
 stop_ids reachable by \code{stop_ids}.
 }
 \description{
-\code{raptor} finds the minimal travel time and/or earliest arrival time for all
+\code{raptor} finds the minimal travel time, earliest or latest arrival time for all
 stops in \code{stop_times} with journeys departing from \code{stop_ids} within
 \code{time_range}.
 }
 \details{
 With a modified \href{https://www.microsoft.com/en-us/research/publication/round-based-public-transit-routing}{Round-Based Public Transit Routing Algorithm}
-(RAPTOR) using data.table earliest arrival times for all stops are calculated. If two
+(RAPTOR) using data.table, earliest arrival times for all stops are calculated. If two
 journeys arrive at the same time, the one with the later departure time and thus shorter
 travel time is kept. By default, all journeys departing within \code{time_range} that arrive
 at a stop are returned in a table. If you want all journeys \emph{arriving} at stop_ids within
 the specified time range, set \code{arrival} to TRUE.
 
-Journeys are defined by a "from" and "to" stop_id, a
-departure, arrival and travel time. Note that the exact journeys (with each intermediate
-stop and route id for example) is \emph{not} returned.
+Journeys are defined by a "from" and "to" stop_id, a departure, arrival and travel time.
+Note that the exact journeys (with each intermediate stop and route ids for example) is
+\emph{not} returned.
 
 For most cases, \code{stop_times} needs to be filtered, as it should only contain trips
 happening on a single day and departures later than a given journey start time, see
@@ -87,7 +87,5 @@ hist(shortest_travel_times$travel_time, breaks = 360)
 }
 }
 \seealso{
-\code{\link[=travel_times]{travel_times()}}
-
-travel_times, filter_stop_times
+\code{\link[=travel_times]{travel_times()}} for an easier access to travel time calculations via stop_names.
 }

--- a/man/raptor.Rd
+++ b/man/raptor.Rd
@@ -4,8 +4,8 @@
 \alias{raptor}
 \title{Calculate travel times from one stop to all reachable stops}
 \usage{
-raptor(stop_times, transfers, from_stop_ids = NULL, to_stop_ids = NULL,
-  departure_time_range = 3600, max_transfers = NULL, keep = "all")
+raptor(stop_times, transfers, stop_ids, departure = TRUE,
+  time_range = 3600, max_transfers = NULL, keep = "all")
 }
 \arguments{
 \item{stop_times}{A (prepared) stop_times table from a gtfs feed. Prepared means
@@ -15,13 +15,14 @@ happening on one day. Use \code{\link[=filter_stop_times]{filter_stop_times()}} 
 
 \item{transfers}{Transfers table from a gtfs feed. In general no preparation is needed.}
 
-\item{from_stop_ids}{character vector with stop_ids from where journeys should start}
+\item{stop_ids}{character vector with stop_ids from where journeys should start}
 
-\item{to_stop_ids}{character vector with stop_ids where journeys should end}
+\item{departure}{If TRUE (default), all journeys \emph{start} from \code{stop_ids}. If
+FALSE, all journeys \emph{end} at \code{stop_ids}.}
 
-\item{departure_time_range}{All departures from the first departure of
-stop_times (not necessarily a from_stop) within
-\code{departure_time_range} (in seconds) are considered.}
+\item{time_range}{All departures from the first departure of stop_times (not necessarily
+from stop_id in \code{stop_ids}) within \code{time_range} (in seconds) are
+considered. If \code{outgoing} is FALSE, all arrivals from}
 
 \item{max_transfers}{Maximum number of transfers allowed, no limit (NULL) as default.}
 
@@ -37,13 +38,13 @@ and their corresponding journey departure and arrival times.
 \description{
 \code{raptor} finds the minimal travel time and/or earliest arrival time for all
 stops in \code{stop_times} with journeys departing from \code{from_stop_ids} within
-\code{departure_time_range}.
+\code{time_range}.
 }
 \details{
 With a modified \href{https://www.microsoft.com/en-us/research/publication/round-based-public-transit-routing}{Round-Based Public Transit Routing Algorithm}
 (RAPTOR) using data.table earliest arrival times for all stops are calculated. If two
 journeys arrive at the same time, the one with the later departure time and thus shorter
-travel time is kept. By default, all journeys within \code{departure_time_range} that arrive
+travel time is kept. By default, all journeys within \code{time_range} that arrive
 at a stop are returned in a table. Journeys are defined by a departure stop_id, a
 departure, arrival and travel time. Note that the exact journeys (with each intermediate
 stop and route id for example) is \emph{not} returned.
@@ -70,7 +71,7 @@ walk_times <- data.frame(stop_id = c(stop_ids_harlem_st, stop_ids_155_st),
 stop_times <- filter_stop_times(nyc, "2018-06-26", 7*3600, 9*3600)
 
 # calculate all journeys departing from Harlem St or 155 St between 7:00 and 7:30
-rptr <- raptor(stop_times, nyc$transfers, walk_times$stop_id, departure_time_range = 1800,
+rptr <- raptor(stop_times, nyc$transfers, walk_times$stop_id, time_range = 1800,
                keep = "all")
 
 # add walk times to travel times
@@ -78,7 +79,7 @@ rptr <- left_join(rptr, walk_times, by=c("from_stop_id" = "stop_id"))
 rptr$travel_time_incl_walk <- rptr$travel_time + rptr$walk_time
 
 # get minimal travel times (with walk times) for all stop_ids 
-shortest_travel_times <- setDT(rptr)[order(travel_time_incl_walk)][, .SD[1], by = "stop_id"]
+shortest_travel_times <- setDT(rptr)[order(travel_time_incl_walk)][, .SD[1], by = "to_stop_id"]
 hist(shortest_travel_times$travel_time, breaks = 360)
 }
 }

--- a/man/travel_times.Rd
+++ b/man/travel_times.Rd
@@ -5,7 +5,7 @@
 \title{Calculate shortest travel times from a stop to all reachable stops}
 \usage{
 travel_times(filtered_stop_times, stop_name, time_range = 3600,
-  departure = TRUE, max_transfers = NULL, max_departure_time = NULL,
+  arrival = FALSE, max_transfers = NULL, max_departure_time = NULL,
   return_coords = FALSE, return_DT = FALSE)
 }
 \arguments{
@@ -16,18 +16,19 @@ deparuture time has been set.}
 \item{stop_name}{stop name for which travel times should becalculated. A vector with
 multiple names is accepted.}
 
-\item{time_range}{All departures within this range in seconds after the first
-departure of \code{filtered_stop_times} are considered for
-journeys.}
+\item{time_range}{All departures within this range in seconds after the first departure
+of \code{filtered_stop_times} are considered for journeys. If arrival is
+TRUE, all journeys arriving within time range before the latest arrival
+of \code{filtered_stop_times} are considered.}
 
-\item{departure}{If TRUE (default), all journeys \emph{start} from \code{stop_name}. If
-FALSE, all journeys \emph{end} at \code{stop_name}.}
+\item{arrival}{If FALSE (default), all journeys \emph{start} from \code{stop_name}. If
+TRUE, all journeys \emph{end} at \code{stop_name}.}
 
 \item{max_transfers}{The maximimum number of transfers}
 
-\item{max_departure_time}{Either set this parameter or \code{time_range}. Only
-departures before \code{max_departure_time} are used. Accepts
-"HH:MM:SS" or seconds as numerical value.}
+\item{max_departure_time}{Either set this parameter or \code{time_range}. Only departures
+before \code{max_departure_time} are used. Accepts "HH:MM:SS" or
+seconds as numerical value. Unused if `arrival`` is TRUE.}
 
 \item{return_coords}{returns stop coordinates as columms. Default is FALSE.}
 
@@ -35,7 +36,7 @@ departures before \code{max_departure_time} are used. Accepts
 returns a tibble/tbl_df.}
 }
 \value{
-A table with travel times to all stops reachable from \code{stop_name} and their
+A table with travel times to/from all stops reachable by \code{stop_name} and their
 corresponding journey departure and arrival times.
 }
 \description{

--- a/man/travel_times.Rd
+++ b/man/travel_times.Rd
@@ -4,37 +4,42 @@
 \alias{travel_times}
 \title{Calculate shortest travel times from a stop to all reachable stops}
 \usage{
-travel_times(filtered_stop_times, from_stop_name,
-  departure_time_range = 3600, max_transfers = NULL,
-  max_departure_time = NULL, return_DT = FALSE)
+travel_times(filtered_stop_times, stop_name, time_range = 3600,
+  departure = TRUE, max_transfers = NULL, max_departure_time = NULL,
+  return_coords = FALSE, return_DT = FALSE)
 }
 \arguments{
 \item{filtered_stop_times}{stop_times data.table (with transfers and stops tables as
 attributes) created with \code{\link[=filter_stop_times]{filter_stop_times()}} where the
 deparuture time has been set.}
 
-\item{from_stop_name}{stop name from which travel times should be calculated. A vector
-with multiple names is accepted.}
+\item{stop_name}{stop name for which travel times should becalculated. A vector with
+multiple names is accepted.}
 
-\item{departure_time_range}{All departures within this range in seconds after the first
+\item{time_range}{All departures within this range in seconds after the first
 departure of \code{filtered_stop_times} are considered for
 journeys.}
 
+\item{departure}{If TRUE (default), all journeys \emph{start} from \code{stop_name}. If
+FALSE, all journeys \emph{end} at \code{stop_name}.}
+
 \item{max_transfers}{The maximimum number of transfers}
 
-\item{max_departure_time}{Either set this parameter or \code{departure_time_range}. Only
+\item{max_departure_time}{Either set this parameter or \code{time_range}. Only
 departures before \code{max_departure_time} are used. Accepts
 "HH:MM:SS" or seconds as numerical value.}
+
+\item{return_coords}{returns stop coordinates as columms. Default is FALSE.}
 
 \item{return_DT}{travel_times() returns a data.table if TRUE. Default is FALSE which
 returns a tibble/tbl_df.}
 }
 \value{
-A table with travel times to all stops reachable from \code{from_stop_name} and their
+A table with travel times to all stops reachable from \code{stop_name} and their
 corresponding journey departure and arrival times.
 }
 \description{
-Function to calculate the shortest travel times from a stop (give by \code{from_stop_name})
+Function to calculate the shortest travel times from a stop (given by \code{stop_name})
 to all other stops of a feed. \code{filtered_stop_times} needs to be created before with
 \code{\link[=filter_stop_times]{filter_stop_times()}}.
 }
@@ -50,15 +55,15 @@ nyc <- read_gtfs(nyc_path)
 # Use journeys departing after 7 AM with arrival time before 9 AM on 26th June
 stop_times <- filter_stop_times(nyc, "2018-06-26", 7*3600, 9*3600)
 
-tts <- travel_times(stop_times, "34 St - Herald Sq")
+tts <- travel_times(stop_times, "34 St - Herald Sq", return_coords = TRUE)
 tts <- tts \%>\% filter(travel_time <= 3600)
 
 # travel time to Queensboro Plaza is 810 seconds, 13:30 minutes
-tts \%>\% filter(stop_name == "Queensboro Plaza") \%>\% dplyr::pull(travel_time) \%>\% hms::hms()
+tts \%>\% filter(to_stop_name == "Queensboro Plaza") \%>\% dplyr::pull(travel_time) \%>\% hms::hms()
 
 # plot a simple map showing travel times to all reachable stops
 # this can be expanded to isochron maps
 library(ggplot2)
-ggplot(tts) + geom_point(aes(x=stop_lon, y=stop_lat, color = travel_time))
+ggplot(tts) + geom_point(aes(x=to_stop_lon, y=to_stop_lat, color = travel_time))
 }
 }

--- a/man/travel_times.Rd
+++ b/man/travel_times.Rd
@@ -28,7 +28,7 @@ TRUE, all journeys \emph{end} at \code{stop_name}.}
 
 \item{max_departure_time}{Either set this parameter or \code{time_range}. Only departures
 before \code{max_departure_time} are used. Accepts "HH:MM:SS" or
-seconds as numerical value. Unused if `arrival`` is TRUE.}
+seconds as numerical value. Unused if \code{arrival} is TRUE.}
 
 \item{return_coords}{returns stop coordinates as columms. Default is FALSE.}
 

--- a/man/travel_times.Rd
+++ b/man/travel_times.Rd
@@ -11,9 +11,9 @@ travel_times(filtered_stop_times, stop_name, time_range = 3600,
 \arguments{
 \item{filtered_stop_times}{stop_times data.table (with transfers and stops tables as
 attributes) created with \code{\link[=filter_stop_times]{filter_stop_times()}} where the
-deparuture time has been set.}
+departure or arrival time has been set.}
 
-\item{stop_name}{stop name for which travel times should becalculated. A vector with
+\item{stop_name}{Stop name for which travel times should be calculated. A vector with
 multiple names is accepted.}
 
 \item{time_range}{All departures within this range in seconds after the first departure
@@ -28,9 +28,9 @@ TRUE, all journeys \emph{end} at \code{stop_name}.}
 
 \item{max_departure_time}{Either set this parameter or \code{time_range}. Only departures
 before \code{max_departure_time} are used. Accepts "HH:MM:SS" or
-seconds as numerical value. Unused if \code{arrival} is TRUE.}
+seconds as a numerical value. Unused if \code{arrival} is TRUE.}
 
-\item{return_coords}{returns stop coordinates as columms. Default is FALSE.}
+\item{return_coords}{Returns stop coordinates as columms. Default is FALSE.}
 
 \item{return_DT}{travel_times() returns a data.table if TRUE. Default is FALSE which
 returns a tibble/tbl_df.}

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -183,6 +183,13 @@ test_that("transfers for travel_times", {
                c(0, 0, 0, 1, 0, 0, 1, 0))
 })
 
+test_that("only max_transfers are used", {
+  expect_equal(max(raptor(stop_times, transfers, from_stop_ids, max_transfers = 0)$transfers), 0)
+  expect_equal(max(raptor(stop_times, transfers, from_stop_ids, max_transfers = 1)$transfers), 1)
+  expect_equal(max(raptor(stop_times, transfers, from_stop_ids, max_transfers = 2)$transfers), 2)
+  expect_equal(max(raptor(stop_times, transfers, from_stop_ids, max_transfers = NULL)$transfers), 2)
+})
+
 test_that("travel_times return type", {
   fst = filter_stop_times(g, "2018-10-01", 0, 24*3600)
   expect_s3_class(travel_times(fst, "One", return_DT = TRUE), "data.frame")

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -117,7 +117,7 @@ test_that("parameters are checked", {
   
   # non-existent stop_id
   expect_warning(raptor(st, tr, "stop99"))
-  expect_warning(raptor(st, tr, 42))
+  expect_error(raptor(st, tr, 42))
   
   # time range type
   expect_error(raptor(st, tr, "stop5", departure_time_range = "char"))

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -79,7 +79,7 @@ test_that("ea and tt return the same result for one departure", {
   earliest_arrival = raptor(stop_times, transfers, from_stop_ids,
                             departure_time_range = 60,
                             keep = "earliest")[order(to_stop_id)]
-  earliest_arrival_tt <- earliest_arrival$min_arrival_time - 7*3600
+  earliest_arrival_tt <- earliest_arrival$journey_arrival_time - 7*3600
 
   expect_equal(shortest_tt, earliest_arrival_tt)
 })
@@ -132,7 +132,7 @@ test_that("parameters are checked", {
 
 test_that("earliest arrival times", {
   r = raptor(stop_times, transfers, "stop2", keep = "earliest")
-  actual = r[order(to_stop_id), min_arrival_time]
+  actual = r[order(to_stop_id), journey_arrival_time]
   expected = c(
     7*3600 + 00*60 + 00, # stop2  07:05:00 departure time
     7*3600 + 11*60 + 00, # stop3a 07:11:00
@@ -146,7 +146,7 @@ test_that("earliest arrival times", {
 
 test_that("earliest arrival time without transfers", {
   r = raptor(stop_times, NULL, from_stop_ids, keep = "earliest")
-  actual = r[order(to_stop_id), min_arrival_time]
+  actual = r[order(to_stop_id), journey_arrival_time]
   expected = c(
     7*3600 + 00*60, # stop1a 07:00
     7*3600 + 00*60, # stop1b 07:12
@@ -225,7 +225,7 @@ test_that("raptor errors without any stop_ids", {
 
 test_that("raptor travel times with to_stop_ids", {
   rptr = raptor(stop_times, transfers, to_stop_ids = "stop4", keep = "shortest")
-  setorder(rptr, journey_departure_stop_id)
+  setorder(rptr, from_stop_id)
   arr_expected = c(
     37*60, # stop1a 
     37*60, # stop1b 
@@ -254,7 +254,7 @@ test_that("raptor travel times with to_stop_ids", {
   )+7*3600
   tt_expected = arr_expected - dep_expected
 
-  expect_equal(rptr$min_arrival_time, arr_expected)
+  expect_equal(rptr$journey_arrival_time, arr_expected)
   expect_equal(rptr$journey_departure_time, dep_expected)
   expect_equal(rptr$travel_time, tt_expected)
   expect_equal(unique(rptr$to_stop_id), "stop4")

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -230,7 +230,7 @@ test_that("raptor errors without any stop_ids", {
 })
 
 test_that("raptor travel times with to_stop_ids", {
-  rptr = raptor(stop_times, transfers, stop_ids = "stop4", departure = FALSE, keep = "shortest")
+  rptr = raptor(stop_times, transfers, stop_ids = "stop4", arrival = TRUE, keep = "shortest")
   setorder(rptr, from_stop_id)
   arr_expected = c(
     37*60, # stop1a 
@@ -269,7 +269,7 @@ test_that("raptor travel times with to_stop_ids", {
 
 test_that("travel_times with departure=FALSE stop_name", {
   fst = filter_stop_times(g, "2018-10-01", 0, 24*3600)
-  tt_to = travel_times(fst, stop_name = "Four", departure = FALSE)
+  tt_to = travel_times(fst, stop_name = "Four", arrival = TRUE)
   tt_to <- tt_to[order(tt_to$from_stop_id),]
   expect_equal(tt_to$journey_arrival_time, hms::hms(c(37,37,37,45,37,37,41,41)*60+7*3600))
 })

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -304,6 +304,16 @@ test_that("raptor with arrival=TRUE and reduced time_range", {
   expect_equal(rptr_2$travel_time, tt_expected_2)
 })
 
+test_that("latest arrivals are correct", {
+  r1 = raptor(stop_times, transfers, stop_ids = "stop1a", arrival = FALSE, keep = "latest")
+  expect_equal(r1[which(r1$to_stop_id == "stop4")]$journey_arrival_time, 41*60+7*3600)
+  expect_equal(r1[which(r1$to_stop_id == "stop3b")]$journey_arrival_time, 28*60+7*3600+10)
+  
+  r2 = raptor(stop_times, transfers, stop_ids = "stop4", arrival = TRUE, keep = "latest")
+  expect_equal(r2[which(r2$from_stop_id == "stop1a")]$journey_arrival_time, 45*60+7*3600)
+  expect_equal(r2[which(r2$from_stop_id == "stop4")]$journey_arrival_time, 45*60+7*3600)
+}
+
 test_that("travel_times with arrival=TRUE stop_name", {
   fst = filter_stop_times(g, "2018-10-01", 0, 24*3600)
   tt_to = travel_times(fst, stop_name = "Four", arrival = TRUE)

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -52,7 +52,7 @@ test_that("raptor travel times", {
   r = raptor(stop_times, transfers,
              from_stop_ids, departure_time_range = 3600,
              keep = "shortest")
-  actual = r[order(stop_id), travel_time]
+  actual = r[order(to_stop_id), travel_time]
   
   expected = c(
     0,          # stop1a 00:00:00
@@ -73,12 +73,12 @@ test_that("raptor travel times", {
 test_that("ea and tt return the same result for one departure", {
   shortest = raptor(stop_times, transfers, from_stop_ids,
                        departure_time_range = 60,
-                       keep = "shortest")[order(stop_id)]
+                       keep = "shortest")[order(to_stop_id)]
   shortest_tt <- shortest$travel_time
   
   earliest_arrival = raptor(stop_times, transfers, from_stop_ids,
                             departure_time_range = 60,
-                            keep = "earliest")[order(stop_id)]
+                            keep = "earliest")[order(to_stop_id)]
   earliest_arrival_tt <- earliest_arrival$min_arrival_time - 7*3600
 
   expect_equal(shortest_tt, earliest_arrival_tt)
@@ -87,12 +87,12 @@ test_that("ea and tt return the same result for one departure", {
 test_that("travel_time with one stop and reduced departure_time_range", {
   r = raptor(stop_times_0709, transfers, "stop1a",
              departure_time_range = 30,
-             keep = "shortest")[order(stop_id)]
+             keep = "shortest")[order(to_stop_id)]
   actual <- r$travel_time
   
   expected = c(
     00*60 + 00, # stop1a 00:00:00
-    00*60 + 10, # stop1b 00:00:00
+    00*60 + 10, # stop1b 00:00:10
     18*60 + 00, # stop3a 00:18:00
     18*60 + 10, # stop3b 00:18:10
     27*60 + 00, # stop4  00:27:00
@@ -132,7 +132,7 @@ test_that("parameters are checked", {
 
 test_that("earliest arrival times", {
   r = raptor(stop_times, transfers, "stop2", keep = "earliest")
-  actual = r[order(stop_id), min_arrival_time]
+  actual = r[order(to_stop_id), min_arrival_time]
   expected = c(
     7*3600 + 00*60 + 00, # stop2  07:05:00 departure time
     7*3600 + 11*60 + 00, # stop3a 07:11:00
@@ -146,7 +146,7 @@ test_that("earliest arrival times", {
 
 test_that("earliest arrival time without transfers", {
   r = raptor(stop_times, NULL, from_stop_ids, keep = "earliest")
-  actual = r[order(stop_id), min_arrival_time]
+  actual = r[order(to_stop_id), min_arrival_time]
   expected = c(
     7*3600 + 00*60, # stop1a 07:00
     7*3600 + 00*60, # stop1b 07:12
@@ -166,10 +166,10 @@ test_that("earliest arrival time without transfers", {
 test_that("transfers are returned", {
   r = raptor(stop_times, transfers, "stop2", keep = "all")
   setorder(r, travel_time)
-  expect_equal(r[stop_id == "stop3a"]$transfers, c(0,0))
-  expect_equal(r[stop_id == "stop4"]$transfers, c(1,0))
-  expect_equal(r[stop_id == "stop8a"]$transfers, 2)
-  expect_equal(r[stop_id == "stop8b"]$transfers, 1)
+  expect_equal(r[to_stop_id == "stop3a"]$transfers, c(0,0))
+  expect_equal(r[to_stop_id == "stop4"]$transfers, c(1,0))
+  expect_equal(r[to_stop_id == "stop8a"]$transfers, 2)
+  expect_equal(r[to_stop_id == "stop8b"]$transfers, 1)
 })
 
 test_that("transfers for travel_times", {
@@ -257,7 +257,7 @@ test_that("raptor travel times with to_stop_ids", {
   expect_equal(rptr$min_arrival_time, arr_expected)
   expect_equal(rptr$journey_departure_time, dep_expected)
   expect_equal(rptr$travel_time, tt_expected)
-  expect_equal(unique(rptr$stop_id), "stop4")
+  expect_equal(unique(rptr$to_stop_id), "stop4")
 })
 
 test_that("raptor with to_stop_ids and from_stop_ids", {

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -312,7 +312,7 @@ test_that("latest arrivals are correct", {
   r2 = raptor(stop_times, transfers, stop_ids = "stop4", arrival = TRUE, keep = "latest")
   expect_equal(r2[which(r2$from_stop_id == "stop1a")]$journey_arrival_time, 45*60+7*3600)
   expect_equal(r2[which(r2$from_stop_id == "stop4")]$journey_arrival_time, 45*60+7*3600)
-}
+})
 
 test_that("travel_times with arrival=TRUE stop_name", {
   fst = filter_stop_times(g, "2018-10-01", 0, 24*3600)

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -222,3 +222,44 @@ test_that("empty return data.table has the same columns as correct", {
 test_that("raptor errors without any stop_ids", {
   expect_error(raptor(stop_times, transfers))
 })
+
+test_that("raptor travel times with to_stop_ids", {
+  rptr = raptor(stop_times, transfers, to_stop_ids = "stop4", keep = "shortest")
+  setorder(rptr, journey_departure_stop_id)
+  arr_expected = c(
+    37*60, # stop1a 
+    37*60, # stop1b 
+    37*60, # stop2   
+    37*60, # stop3a
+    37*60, # stop3b
+    45*60, # stop4
+    37*60, # stop5
+    37*60, # stop6
+    41*60, # stop7
+    41*60, # stop8a
+    41*60  # stop8b
+  )+7*3600
+  dep_expected = c(
+    17*60 - 10, # stop1a 
+    17*60 - 00, # stop1b 
+    09*60 - 00, # stop2   
+    28*60 - 00, # stop3a
+    28*60 - 10, # stop3b
+    45*60 - 00, # stop4
+    15*60 - 00, # stop5
+    20*60 - 00, # stop6
+    25*60 - 00, # stop7
+    32*60 - 00, # stop8a
+    32*60 - 10  # stop8b
+  )+7*3600
+  tt_expected = arr_expected - dep_expected
+
+  expect_equal(rptr$min_arrival_time, arr_expected)
+  expect_equal(rptr$journey_departure_time, dep_expected)
+  expect_equal(rptr$travel_time, tt_expected)
+  expect_equal(unique(rptr$stop_id), "stop4")
+})
+
+test_that("raptor with to_stop_ids and from_stop_ids", {
+  expect_error(raptor(stop_times, transfers))
+})

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -229,7 +229,7 @@ test_that("raptor errors without any stop_ids", {
   expect_error(raptor(stop_times, transfers))
 })
 
-test_that("raptor travel times with to_stop_ids", {
+test_that("raptor travel times with arrival=TRUE", {
   rptr = raptor(stop_times, transfers, stop_ids = "stop4", arrival = TRUE, keep = "shortest")
   setorder(rptr, from_stop_id)
   arr_expected = c(
@@ -248,13 +248,13 @@ test_that("raptor travel times with to_stop_ids", {
   dep_expected = c(
     17*60 - 10, # stop1a 
     17*60 - 00, # stop1b 
-    09*60 - 00, # stop2   
-    28*60 - 00, # stop3a
-    28*60 - 10, # stop3b
+    10*60 - 00, # stop2   
+    29*60 - 00, # stop3a
+    29*60 - 10, # stop3b
     45*60 - 00, # stop4
     15*60 - 00, # stop5
-    20*60 - 00, # stop6
-    25*60 - 00, # stop7
+    21*60 - 00, # stop6
+    26*60 - 00, # stop7
     32*60 - 00, # stop8a
     32*60 - 10  # stop8b
   )+7*3600
@@ -266,10 +266,49 @@ test_that("raptor travel times with to_stop_ids", {
   expect_equal(unique(rptr$to_stop_id), "stop4")
 })
 
+test_that("raptor with arrival=TRUE and reduced time_range", {
+  rptr_2 = raptor(stop_times, transfers, stop_ids = "stop4", 
+                arrival = TRUE, time_range = 5*60,
+                keep = "shortest")
+  setorder(rptr_2, from_stop_id)
+  arr_expected_2 = c(
+    40*60, # stop1a 
+    40*60, # stop1b 
+    40*60, # stop2   
+    40*60, # stop3a
+    40*60, # stop3b
+    45*60, # stop4
+    40*60, # stop5
+    40*60, # stop6
+    41*60, # stop7
+    41*60, # stop8a
+    41*60  # stop8b
+  )+7*3600
+  dep_expected_2 = c(
+    17*60 - 10, # stop1a
+    17*60 - 00, # stop1b 
+    10*60 - 00, # stop2   
+    29*60 - 00, # stop3a
+    29*60 - 10, # stop3b
+    45*60 - 00, # stop4
+    15*60 - 00, # stop5
+    21*60 - 00, # stop6
+    26*60 - 00, # stop7
+    32*60 - 00, # stop8a
+    32*60 - 10  # stop8b
+  )+7*3600
+  tt_expected_2 = arr_expected_2 - dep_expected_2
 
-test_that("travel_times with departure=FALSE stop_name", {
+  expect_equal(rptr_2$journey_arrival_time, arr_expected_2)
+  expect_equal(rptr_2$journey_departure_time, dep_expected_2)
+  expect_equal(rptr_2$travel_time, tt_expected_2)
+})
+
+test_that("travel_times with arrival=TRUE stop_name", {
   fst = filter_stop_times(g, "2018-10-01", 0, 24*3600)
   tt_to = travel_times(fst, stop_name = "Four", arrival = TRUE)
   tt_to <- tt_to[order(tt_to$from_stop_id),]
   expect_equal(tt_to$journey_arrival_time, hms::hms(c(37,37,37,45,37,37,41,41)*60+7*3600))
 })
+
+

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -260,6 +260,24 @@ test_that("raptor travel times with to_stop_ids", {
   expect_equal(unique(rptr$to_stop_id), "stop4")
 })
 
-test_that("raptor with to_stop_ids and from_stop_ids", {
+
+test_that("travel_times with to_stop_name", {
+  tt_to = travel_times(fst, to_stop_name = "Four")
+  tt_to <- tt_to[order(tt_to$from_stop_id),]
+  expect_equal(tt_to$journey_arrival_time, hms::hms(c(37,37,37,45,37,37,41,41)*60+7*3600))
+})
+
+test_that("raptor and travel_times with to_stop_ids and from_stop_ids", {
+  fst = filter_stop_times(g, "2018-10-01", 0, 24*3600)
+  
   expect_error(raptor(stop_times, transfers))
+  expect_error(travel_times(fst))
+  
+  rr_frto = raptor(stop_times, transfers, c("stop1a", "stop1b"), c("stop4"), keep = "shortest")
+  tt_frto = travel_times(fst, from_stop_name = "One", to_stop_name = "Four")
+  expect_equal(nrow(tt_frto), 1)
+  expect_equal(tt_frto$travel_time, rr_frto$travel_time)
+  
+  rr_13_0t = raptor(stop_times, transfers, c("stop1a", "stop1b"), c("stop3a", "stop3b"), max_transfers = 0)
+  expect_equal(nrow(rr_13_0t), 5)
 })

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -211,3 +211,7 @@ test_that("empty return data.table has the same columns as correct", {
   r2 = raptor(stop_times_0711, transfers, "stop3a")
   expect_equal(colnames(r1), colnames(r2))
 })
+
+test_that("raptor errors without any stop_ids", {
+  expect_error(raptor(stop_times, transfers))
+})

--- a/tests/testthat/test-raptor.R
+++ b/tests/testthat/test-raptor.R
@@ -3,7 +3,7 @@ context("raptor travel time routing")
 local_gtfs_path <- system.file("extdata", "routing.zip", package = "tidytransit")
 g <- read_gtfs(local_gtfs_path)
 g <- set_hms_times(g)
-from_stop_ids <- c("stop1a", "stop1b")
+test_from_stop_ids <- c("stop1a", "stop1b")
 
 stop_times = g$stop_times
 stop_times_0709 = dplyr::filter(g$stop_times, departure_time_hms >= 7*3600+10*60)
@@ -18,15 +18,15 @@ test_that("travel times wrapper function", {
     from_stop_name = "One", 
     departure_time_range = 3600)
   expect_equal(nrow(tt), length(unique(g$stops$stop_name)))
-  expect_equal(tt %>% dplyr::filter(stop_name == "One") %>% dplyr::pull(travel_time), 0)
-  expect_equal(tt$travel_time[which(tt$stop_name == "One")], 0)
-  expect_equal(tt$travel_time[which(tt$stop_name == "Two")], 4*60)
-  expect_equal(tt$travel_time[which(tt$stop_name == "Three")], (18-12)*60)
-  expect_equal(tt$travel_time[which(tt$stop_name == "Four")], (37-17)*60)
-  expect_equal(tt$travel_time[which(tt$stop_name == "Five")], (15-10)*60)
-  expect_equal(tt$travel_time[which(tt$stop_name == "Six")], (20-10)*60)
-  expect_equal(tt$travel_time[which(tt$stop_name == "Seven")], (25-10)*60)
-  expect_equal(tt$travel_time[which(tt$stop_name == "Eight")], (24-12)*60)
+  expect_equal(tt %>% dplyr::filter(to_stop_name == "One") %>% dplyr::pull(travel_time), 0)
+  expect_equal(tt$travel_time[which(tt$to_stop_name == "One")], 0)
+  expect_equal(tt$travel_time[which(tt$to_stop_name == "Two")], 4*60)
+  expect_equal(tt$travel_time[which(tt$to_stop_name == "Three")], (18-12)*60)
+  expect_equal(tt$travel_time[which(tt$to_stop_name == "Four")], (37-17)*60)
+  expect_equal(tt$travel_time[which(tt$to_stop_name == "Five")], (15-10)*60)
+  expect_equal(tt$travel_time[which(tt$to_stop_name == "Six")], (20-10)*60)
+  expect_equal(tt$travel_time[which(tt$to_stop_name == "Seven")], (25-10)*60)
+  expect_equal(tt$travel_time[which(tt$to_stop_name == "Eight")], (24-12)*60)
 })
 
 test_that("travel_time works with different params", {
@@ -50,7 +50,7 @@ test_that("stop times are filtered correctly", {
 
 test_that("raptor travel times", {
   r = raptor(stop_times, transfers,
-             from_stop_ids, departure_time_range = 3600,
+             test_from_stop_ids, departure_time_range = 3600,
              keep = "shortest")
   actual = r[order(to_stop_id), travel_time]
   
@@ -71,12 +71,12 @@ test_that("raptor travel times", {
 })
 
 test_that("ea and tt return the same result for one departure", {
-  shortest = raptor(stop_times, transfers, from_stop_ids,
+  shortest = raptor(stop_times, transfers, test_from_stop_ids,
                        departure_time_range = 60,
                        keep = "shortest")[order(to_stop_id)]
   shortest_tt <- shortest$travel_time
   
-  earliest_arrival = raptor(stop_times, transfers, from_stop_ids,
+  earliest_arrival = raptor(stop_times, transfers, test_from_stop_ids,
                             departure_time_range = 60,
                             keep = "earliest")[order(to_stop_id)]
   earliest_arrival_tt <- earliest_arrival$journey_arrival_time - 7*3600
@@ -145,7 +145,7 @@ test_that("earliest arrival times", {
 })
 
 test_that("earliest arrival time without transfers", {
-  r = raptor(stop_times, NULL, from_stop_ids, keep = "earliest")
+  r = raptor(stop_times, NULL, test_from_stop_ids, keep = "earliest")
   actual = r[order(to_stop_id), journey_arrival_time]
   expected = c(
     7*3600 + 00*60, # stop1a 07:00
@@ -178,16 +178,16 @@ test_that("transfers for travel_times", {
     filtered_stop_times = fst, 
     from_stop_name = "One", 
     departure_time_range = 3600) %>% 
-    arrange(stop_id)
+    arrange(to_stop_id)
   expect_equal(tt$transfers, 
                c(0, 0, 0, 1, 0, 0, 1, 0))
 })
 
 test_that("only max_transfers are used", {
-  expect_equal(max(raptor(stop_times, transfers, from_stop_ids, max_transfers = 0)$transfers), 0)
-  expect_equal(max(raptor(stop_times, transfers, from_stop_ids, max_transfers = 1)$transfers), 1)
-  expect_equal(max(raptor(stop_times, transfers, from_stop_ids, max_transfers = 2)$transfers), 2)
-  expect_equal(max(raptor(stop_times, transfers, from_stop_ids, max_transfers = NULL)$transfers), 2)
+  expect_equal(max(raptor(stop_times, transfers, test_from_stop_ids, max_transfers = 0)$transfers), 0)
+  expect_equal(max(raptor(stop_times, transfers, test_from_stop_ids, max_transfers = 1)$transfers), 1)
+  expect_equal(max(raptor(stop_times, transfers, test_from_stop_ids, max_transfers = 2)$transfers), 2)
+  expect_equal(max(raptor(stop_times, transfers, test_from_stop_ids, max_transfers = NULL)$transfers), 2)
 })
 
 test_that("travel_times return type", {


### PR DESCRIPTION
With this pull request it's now possible to calculate travel times for _incoming_ journeys by using the new parameter `arrival=TRUE`. This is done by "reversing" stop_times internally. It's now also possible to keep the latest arriving journey with `keep="latest"`.  This allows to answer questions like "who can reach this location before 8 am with at most 30 minutes of traveling". Previously, `raptor` and `travel_times` could only calculate journeys departing from a stop. 

There are some breaking changes, the following parameters have been renamed:
- `from_stop_id` changed to `stop_id`
- `from_stop_name` changed to `stop_name`
- `departure_time_range` changed to `time_range`

The column names of the returned tables have been changed:
- `min_arrival_time` to `journey_arrival_time`
- `stop_id` to `to_stop_id`
- `journey_departure_stop_id` to `from_stop_id`

In addition, a bug where `max_transfers` wasn't used correctly has been fixed.