### PR TITLE
bug fix: wrong shape ids in shapes_as_sf

### DIFF
--- a/R/spatial.R
+++ b/R/spatial.R
@@ -51,7 +51,7 @@ shapes_as_sf <- function(gtfs_shapes) {
   
   shape_linestrings <- sf::st_sfc(list_of_linestrings, crs = 4326)
   
-  shapes_sf <- sf::st_sf(shape_id = unique(gtfs_shapes$shape_id), geometry = shape_linestrings)
+  shapes_sf <- sf::st_sf(shape_id = names(list_of_line_tibbles), geometry = shape_linestrings)
   shapes_sf$shape_id <- as.character(shapes_sf$shape_id)
   
   return(shapes_sf)


### PR DESCRIPTION
potentially wrong shape ids are returned from the function shapes_as_sf (e.g. Berlin GTFS Feed).

unique(gtfs_shapes$shape_id) does not necessarily have the same order of shape ids (because of the split function in line 49).
Instead: use names(list_of_line_tibbles)