### PR TITLE
Write_gtfs to directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,17 @@ cache:
 
 latex: false
 
-before_install:
-  - sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable --yes
-  - sudo apt-get --yes --force-yes update -qq
-  - sudo apt-get install --yes libproj-dev libgeos-dev libgdal-dev libudunits2-dev
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntugis/ubuntugis-unstable'
+    packages:
+      - libudunits2-dev
+      - libproj-dev
+      - libgeos-dev
+      - libspatialite-dev
+      - libgdal-dev
+      - libjson-c-dev
+
+after_success:
+  - R -q -e 'covr::codecov(quiet = FALSE)'

--- a/R/utils.R
+++ b/R/utils.R
@@ -95,7 +95,7 @@ write_gtfs <- function(gtfs_obj, zipfile, compression_level = 9, as_dir = FALSE)
     cn <- colnames(dd)[which(!(colnames(dd) %in% c("arrival_time_hms", "departure_time_hms", "start_time_hms", "end_time_hms")))]
     dd <- dd[cn]
 
-    readr::write_csv(dd, paste0(outdir, "/", filename, ".txt"))
+    readr::write_csv(dd, paste0(outdir, "/", filename, ".txt"), na = "")
   }
   if(!as_dir) {
     filelist = paste0(outdir, "/", filenames, ".txt")

--- a/man/write_gtfs.Rd
+++ b/man/write_gtfs.Rd
@@ -4,7 +4,7 @@
 \alias{write_gtfs}
 \title{Writes a gtfs object to a zip file. Calculated tidytransit tables and columns are not exported.}
 \usage{
-write_gtfs(gtfs_obj, zipfile, compression_level = 9)
+write_gtfs(gtfs_obj, zipfile, compression_level = 9, as_dir = FALSE)
 }
 \arguments{
 \item{gtfs_obj}{a gtfs feed object}
@@ -12,6 +12,8 @@ write_gtfs(gtfs_obj, zipfile, compression_level = 9)
 \item{zipfile}{path to the zip file the feed should be written to}
 
 \item{compression_level}{a number between 1 and 9.9, passed to zip::zip}
+
+\item{as_dir}{if TRUE, the feed is not zipped and zipfile is used as a directory path. Files within the directory will be overwritten.}
 }
 \description{
 Writes a gtfs object to a zip file. Calculated tidytransit tables and columns are not exported.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -13,3 +13,14 @@ if (Sys.getenv("USER") != "travis") {
     expect_error(write_gtfs(g1$agency, path2))
   })
 }
+
+if (Sys.getenv("USER") != "travis") {
+  test_that("write_gtfs as_dir", {
+    skip_on_cran()
+    path1 <- system.file("extdata", "sample-feed-fixed.zip", package = "tidytransit")
+    path2 <- tempdir()
+    g1 <- read_gtfs(path1)
+    write_gtfs(g1, path2, as_dir = TRUE)
+    expect_true(file.exists(paste0(path2, "/agency.txt")))
+  })
+}


### PR DESCRIPTION
With this PR, write_gtfs can write a feed to a directory which makes data transfer with other programs easier if necessary. In addition, NA values are written as empty csv cells.