### PR TITLE
update url's

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ frequencies, and validate transit feeds. Tidytransit reads the
 [tidyverse](https://tibble.tidyverse.org/) and 
 [simple features](https://en.wikipedia.org/wiki/Simple_Features) data frames. 
 Tidytransit can be used to:
-- [read GTFS feeds into R](http://tidytransit.r-transit.org/reference/read_gtfs.html)
-- [calculate travel times between transit stops](http://tidytransit.r-transit.org/reference/travel_times.html)
-- [convert stops and routes to sf data frames](http://tidytransit.r-transit.org/reference/gtfs_as_sf.html)
-- [validate transit feeds and more](http://tidytransit.r-transit.org/reference/index.html)
+- [read GTFS feeds into R](http://r-transit.github.io/tidytransit/reference/read_gtfs.html)
+- [calculate travel times between transit stops](http://r-transit.github.io/tidytransit/reference/travel_times.html)
+- [convert stops and routes to sf data frames](http://r-transit.github.io/tidytransit/reference/gtfs_as_sf.html)
+- [validate transit feeds and more](http://r-transit.github.io/tidytransit/reference/index.html)
 
 Have a look at the following vignettes to see how tidytransit can be used to analyse a feed:
 
-- [introduction](http://tidytransit.r-transit.org/articles/introduction.html) 
-- [calendar and service patterns](http://tidytransit.r-transit.org/articles/servicepatterns.html)
-- [create time tables for stops](http://tidytransit.r-transit.org/articles/timetable.html)
-- [frequency and headway calculations](http://tidytransit.r-transit.org/articles/frequency.html)  
+- [introduction](http://r-transit.github.io/tidytransit/articles/introduction.html) 
+- [calendar and service patterns](http://r-transit.github.io/tidytransit/articles/servicepatterns.html)
+- [create time tables for stops](http://r-transit.github.io/tidytransit/articles/timetable.html)
+- [frequency and headway calculations](http://r-transit.github.io/tidytransit/articles/frequency.html)  
 
 ## Installation
 

--- a/vignettes/frequency.Rmd
+++ b/vignettes/frequency.Rmd
@@ -27,12 +27,12 @@ The focus of this vignette is on how to use R to make graphics about where and h
 transit service operates based on schedule data published in the [General Transit Feed Specification](https://gtfs.org/). 
 We'll focus on the New York City Metropolitan Transit Agency's Subway schedule for this 
 vignette, but you can easily apply it to thousands of other GTFS data sources. See the 
-[tidytransit introductory vignette](https://tidytransit.r-transit.org/articles/introduction.html#finding-more-gtfs-feeds) 
+[tidytransit introductory vignette](https://r-transit.github.io/tidytransit/articles/introduction.html#finding-more-gtfs-feeds) 
 for instructions on finding data for other cities and operators. 
 
 ## Setup
 
-You'll need to have tidytransit installed. Please see the [install instructions](https://tidytransit.r-transit.org/articles/introduction.html#installation-dependencies) for more details. 
+You'll need to have tidytransit installed. Please see the [install instructions](https://r-transit.github.io/tidytransit/articles/introduction.html#installation-dependencies) for more details. 
 
 ## Outline
 
@@ -47,7 +47,7 @@ So, to review, we're going to:
 ### 1) Import Transit Data (GTFS)
 
 We'll start by importing a snapshot of the NYC MTA's subway schedule, which is included 
-with the package when [installed](https://tidytransit.r-transit.org/index.html#installation).  
+with the package when [installed](https://r-transit.github.io/tidytransit/index.html#installation).  
 
 ```{r}
 local_gtfs_path <- system.file("extdata", "google_transit_nyc_subway.zip", package = "tidytransit")
@@ -66,7 +66,7 @@ MTA's URL directly.
 GTFS feeds typically contain a schedule of all the schedules of service for a given system. 
 Selecting a schedule of service in NYC allows us to focus on, for example, non-holiday 
 weekday service, in the Fall of 2019. In some feeds, service selection can be more or less 
-complicated than NYC. In any case, you'll want to read the [service patterns](http://tidytransit.r-transit.org/articles/servicepatterns.html) 
+complicated than NYC. In any case, you'll want to read the [service patterns](http://r-transit.github.io/tidytransit/articles/servicepatterns.html) 
 vignette included in this package in order to see how you can select the right service for 
 your needs. 
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -21,13 +21,13 @@ library(dplyr)
 
 Use tidytransit to:
 
-- [Read a GTFS Feed into R Data Types](https://tidytransit.r-transit.org/articles/introduction.html#read-a-gtfs-feed)
-- [Validate transit feeds](https://tidytransit.r-transit.org/articles/introduction.html#feed-validation-results)
-- [Convert stops and routes to 'simple features'](https://tidytransit.r-transit.org/reference/gtfs_as_sf.html) and [plot them](https://tidytransit.r-transit.org/reference/plot.tidygtfs.html)
-- [Calculate travel times between transit stops](https://tidytransit.r-transit.org/reference/travel_times.html)
-- [Analyse route frequency and headways](https://tidytransit.r-transit.org/articles/servicepatterns.html)
-- [Analyse calendar data](https://tidytransit.r-transit.org/articles/servicepatterns.html)
-- [Create time tables for stops](https://tidytransit.r-transit.org/articles/timetable.html)
+- [Read a GTFS Feed into R Data Types](https://r-transit.github.io/tidytransit/articles/introduction.html#read-a-gtfs-feed)
+- [Validate transit feeds](https://r-transit.github.io/tidytransit/articles/introduction.html#feed-validation-results)
+- [Convert stops and routes to 'simple features'](https://r-transit.github.io/tidytransit/reference/gtfs_as_sf.html) and [plot them](https://r-transit.github.io/tidytransit/reference/plot.tidygtfs.html)
+- [Calculate travel times between transit stops](https://r-transit.github.io/tidytransit/reference/travel_times.html)
+- [Analyse route frequency and headways](https://r-transit.github.io/tidytransit/articles/servicepatterns.html)
+- [Analyse calendar data](https://r-transit.github.io/tidytransit/articles/servicepatterns.html)
+- [Create time tables for stops](https://r-transit.github.io/tidytransit/articles/timetable.html)
 
 # Installation & Dependencies
 


### PR DESCRIPTION
since r-transit.org is no longer the url for the docs.

cc @polettif. 

i gave up the r-transit.org url. 

since the docs are here on github it just seems simpler. 

looking back, i should have filed a change of address with google before doing so. but now its too late. apologies!