### PR TITLE
Suppress multiple match warning

### DIFF
--- a/R/spatial.R
+++ b/R/spatial.R
@@ -146,7 +146,9 @@ get_trip_geometry <- function(gtfs_sf_obj, trip_ids) {
   }
 
   trips = gtfs_sf_obj$trips %>% filter(trip_id %in% trip_ids)
-  trips_shapes = dplyr::inner_join(gtfs_sf_obj$shapes, trips, by = "shape_id")
+  trips_shapes = suppress_matches_multiple_warning(
+    dplyr::inner_join(gtfs_sf_obj$shapes, trips, by = "shape_id")
+  )
   return(trips_shapes)
 }
 

--- a/R/time.R
+++ b/R/time.R
@@ -179,7 +179,9 @@ set_dates_services <- function(gtfs_obj) {
     
     # set services to dates according to weekdays and start/end date
     date_service_df <- 
-      dplyr::full_join(dates, service_ids_weekdays, by="weekday") %>% 
+      suppress_matches_multiple_warning(
+        dplyr::full_join(dates, service_ids_weekdays, by="weekday")
+      ) %>% 
       dplyr::filter(date >= start_date & date <= end_date) %>% 
       dplyr::select(-weekday, -start_date, -end_date)
     

--- a/R/utils.R
+++ b/R/utils.R
@@ -48,3 +48,16 @@ na_to_empty_strings = function(gtfs_obj) {
     df
   })
 }
+
+# TODO: Remove after dplyr 1.1.0 is released and use `multiple = "all"` instead
+suppress_matches_multiple_warning <- function(expr) {
+  handler_matches_multiple <- function(cnd) {
+    if (inherits(cnd, "dplyr_warning_join_matches_multiple")) {
+      restart <- findRestart("muffleWarning")
+      if (!is.null(restart)) {
+        invokeRestart(restart)
+      }
+    }
+  }
+  withCallingHandlers(expr, warning = handler_matches_multiple)
+}


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. In the meantime, to be compatible with both dev and CRAN dplyr we need to work around broken tests of yours that were expecting no warnings. I've done that by suppressing the warnings in the join calls that caused errors. You can switch to explicitly setting `multiple = "all"` instead after the dplyr 1.1.0 release, but this should work for both dev and CRAN dplyr in the meantime.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!