### PR TITLE
Fix for dplyr 1.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ LazyData: TRUE
 Depends: R (>= 3.6.0)
 Imports:
     gtfsio (>= 0.1.0),
-    dplyr,
+    dplyr (>= 1.1.0),
     data.table (>= 1.12.8),
     rlang,
     sf,

--- a/R/dates.R
+++ b/R/dates.R
@@ -93,11 +93,11 @@ set_dates_services <- function(gtfs_obj) {
       dplyr::filter(bool == 1) %>% dplyr::select(service_id, weekday, start_date, end_date)
     
     # set services to dates according to weekdays and start/end date
-    date_service_df <- 
-      suppress_matches_multiple_warning(
-        dplyr::full_join(dates, service_ids_weekdays, by="weekday")
+    date_service_df <- dates %>%
+      dplyr::inner_join(
+        service_ids_weekdays, 
+        by = dplyr::join_by(weekday, between(date, start_date, end_date))
       ) %>% 
-      dplyr::filter(date >= start_date & date <= end_date) %>% 
       dplyr::select(-weekday, -start_date, -end_date)
     
     # addtions and exceptions

--- a/R/globals.R
+++ b/R/globals.R
@@ -50,7 +50,8 @@ if (getRversion() >= "3.1.0") {
       "start_time",
       "end_time",
       "feed_start_date",
-      "feed_end_date"
+      "feed_end_date",
+      "between"
     )
   )
 }

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -146,9 +146,14 @@ get_trip_geometry <- function(gtfs_sf_obj, trip_ids) {
   }
 
   trips = gtfs_sf_obj$trips %>% filter(trip_id %in% trip_ids)
-  trips_shapes = suppress_matches_multiple_warning(
-    dplyr::inner_join(gtfs_sf_obj$shapes, trips, by = "shape_id")
-  )
+  
+  if (utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    trips_shapes = dplyr::inner_join(gtfs_sf_obj$shapes, trips, by = "shape_id")
+  } else {
+    # TODO: Remove after dplyr 1.1.1 is released
+    trips_shapes = dplyr::inner_join(gtfs_sf_obj$shapes, trips, by = "shape_id", multiple = "all")
+  }
+  
   return(trips_shapes)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -48,16 +48,3 @@ na_to_empty_strings = function(gtfs_obj) {
     df
   })
 }
-
-# TODO: Remove after dplyr 1.1.0 is released and use `multiple = "all"` instead
-suppress_matches_multiple_warning <- function(expr) {
-  handler_matches_multiple <- function(cnd) {
-    if (inherits(cnd, "dplyr_warning_join_matches_multiple")) {
-      restart <- findRestart("muffleWarning")
-      if (!is.null(restart)) {
-        invokeRestart(restart)
-      }
-    }
-  }
-  withCallingHandlers(expr, warning = handler_matches_multiple)
-}


### PR DESCRIPTION
We are preparing to release dplyr 1.1.1 and this package popped up in the revdep checks.

We realized that we didn't get the `multiple` argument quite right the first time around 😞 . It was too aggressive since it warned on both one-to-many and many-to-many joins. In 1.1.1 we've made two improvements:
- `multiple` now defaults to `"all"`. The options of `NULL`, `"error"`, and `"warning"` are deprecated.
- `relationship` is a new argument to add known constraints onto the join procedure, such as `"many-to-one"`, which replaces `multiple = "error"`.

The default of `relationship` checks to see if there is a `many-to-many` relationship between the keys of `x` and `y` and will warn if one is present. This should be _much_ rarer than what we checked for before, and targets the most dangerous case that we were trying to warn the user about.

You can read all about `relationship` here https://github.com/tidyverse/dplyr/pull/6753, along with the issues linked there.

Unfortunately it does affect some code here, but I think it does so in a positive way!
- You can use a non-equi join in `set_dates_service()` which makes it faster and simpler
- The `inner_join()` in `get_trip_geometry()` no longer needs `multiple` to be set. It seems like it was doing a one-to-many join before, which we no longer warn on. But we do have to branch on the dplyr version for this one to support CRAN and dev dplyr.

We plan to submit dplyr 1.1.1 in 2-3 weeks.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!