### PR TITLE
Improve duplicated primary key check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
     scales,
     lubridate,
     leaflet
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 URL: https://github.com/r-transit/tidytransit
 BugReports: https://github.com/r-transit/tidytransit
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
As it turns out, the implemented check for duplicated primary keys is _very_ slow on larger feeds. This PR improves the runtime by about 10x (!) by using `data.table::anyDuplicated`. Example benchmarks:

With the NYC dataset 
```r
nyc = gtfsio::import_gtfs(system.file("extdata", "google_transit_nyc_subway.zip", package = "tidytransit"))
duplicated_primary_keys(nyc)
```
```
Unit: milliseconds
 expr       min       lq      mean    median        uq      max neval
  old 531.28157 624.1847 673.41524 696.80770 714.99092 763.3479    20
  new  26.70495  30.0662  43.68424  33.98627  46.30624 106.0321    20
```

With the [Swiss dataset](https://opentransportdata.swiss/en/dataset/timetable-2023-gtfs2020):
```
Unit: seconds
 expr       min        lq      mean    median        uq       max neval
  old 16.113029 17.393730 18.626484 17.964645 20.772904 20.888113     5
  new  1.063265  1.117334  1.569431  1.244815  1.675949  2.745791     5
```

Maybe there's faster ways to check for duplicated keys but I can't think of a better way currently. Checking for unique keys in large datasets is bound to come with some cost.
