### PR TITLE
depend on dplyr >= 1.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ LazyData: TRUE
 Depends: R (>= 3.6.0)
 Imports:
     gtfsio (>= 1.1.0),
-    dplyr (>= 1.1.0),
+    dplyr (>= 1.1.1),
     data.table (>= 1.12.8),
     rlang,
     sf,

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -147,13 +147,8 @@ get_trip_geometry <- function(gtfs_sf_obj, trip_ids) {
 
   trips = gtfs_sf_obj$trips %>% filter(trip_id %in% trip_ids)
   
-  if (utils::packageVersion("dplyr") >= "1.1.0.9000") {
-    trips_shapes = dplyr::inner_join(gtfs_sf_obj$shapes, trips, by = "shape_id")
-  } else {
-    # TODO: Remove after dplyr 1.1.1 is released
-    trips_shapes = dplyr::inner_join(gtfs_sf_obj$shapes, trips, by = "shape_id", multiple = "all")
-  }
-  
+  trips_shapes = dplyr::inner_join(gtfs_sf_obj$shapes, trips, by = "shape_id")
+
   return(trips_shapes)
 }
 


### PR DESCRIPTION
I think it's safe to bump the dplyr version and remove the hotfix introduced in #197 