### PR TITLE
Add include_parent_stations parameter to filter functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,9 +44,9 @@ Suggests:
     scales,
     lubridate,
     leaflet
-RoxygenNote: 7.3.3
 URL: https://github.com/r-transit/tidytransit, https://r-transit.github.io/tidytransit/
 BugReports: https://github.com/r-transit/tidytransit/issues
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Encoding: UTF-8
+Config/roxygen2/version: 8.0.0

--- a/R/filters.R
+++ b/R/filters.R
@@ -26,18 +26,11 @@ filter_stops <- function(gtfs_obj, service_ids, route_ids, include_parent_statio
   some_stop_times <- filter(gtfs_obj$stop_times,
                             trip_id %in% some_trips$trip_id) 
   
-  some_stops <- filter(gtfs_obj$stops,
-                       stop_id %in% some_stop_times$stop_id)
-  if(include_parent_stations) {
-    some_stops <- some_stops |> 
-      bind_rows(
-        gtfs$stops |> 
-          filter(
-            stop_id %in% some_stops$parent_station 
-            & !(stop_id %in% some_stops$stop_id)
-          )
-      )
-  }
+  some_stops <- filter(
+    gtfs_obj$stops,
+    stop_id %in% some_stop_times$stop_id | 
+    (include_parent_stations & stop_id %in% gtfs_obj$stops$parent_station[gtfs_obj$stops$stop_id %in% some_stop_times$stop_id])
+  )
   
   return(some_stops)
 }
@@ -66,10 +59,11 @@ filter_feed_by_trips = function(gtfs_obj, trip_ids, include_parent_stations = FA
   # other
   trip_stop_ids = gtfs_obj$stop_times$stop_id
   service_ids = unique(gtfs_obj$trips$service_id)
-  some_stops <- gtfs_obj$stops[which(gtfs_obj$stops$stop_id %in% trip_stop_ids),]
-  if (include_parent_stations) {
-    some_stops <- some_stops |> bind_rows(gtfs_obj$stops |> filter(stop_id %in% some_stops$parent_station & !(stop_id %in% some_stops$stop_id)))
-  }
+  some_stops <- filter(
+    gtfs_obj$stops,
+    stop_id %in% trip_stop_ids | 
+    (include_parent_stations & stop_id %in% gtfs_obj$stops$parent_station[gtfs_obj$stops$stop_id %in% trip_stop_ids])
+  )
   gtfs_obj$stops <- some_stops
   
   gtfs_obj$.$dates_services <- gtfs_obj$.$dates_services[which(gtfs_obj$.$dates_services$service_id %in% service_ids),]

--- a/R/filters.R
+++ b/R/filters.R
@@ -122,7 +122,7 @@ filter_feed_by_area <- function(gtfs_obj, area, include_parent_stations = FALSE)
     stop_ids <- unique(stop_ids$stop_id)
   }
   
-  filter_feed_by_stops(gtfs_obj, stop_ids, include_parent_stations)
+  filter_feed_by_stops(gtfs_obj, stop_ids = stop_ids, include_parent_stations = include_parent_stations)
 }
 
 #' Filter a gtfs feed so that it only contains trips that pass the given stops

--- a/R/filters.R
+++ b/R/filters.R
@@ -164,6 +164,7 @@ filter_feed_by_stops = function(gtfs_obj, stop_ids = NULL, stop_names = NULL, in
 #' @inherit filter_feed_by_trips description return
 #' 
 #' @inheritParams filter_stop_times
+#' @param include_parent_stations whether to include stops refered in the parent_station column or not
 #' 
 #' @seealso [filter_feed_by_area()], [filter_feed_by_stops()], [filter_feed_by_trips()]
 #' 

--- a/R/filters.R
+++ b/R/filters.R
@@ -70,7 +70,7 @@ filter_feed_by_trips = function(gtfs_obj, trip_ids, include_parent_stations = TR
   if (include_parent_stations) {
     some_stops <- some_stops |> bind_rows(gtfs_obj$stops |> filter(stop_id %in% some_stops$parent_station & !(stop_id %in% some_stops$stop_id)))
   }
-  gtfs_obj $ stops <- some_stops
+  gtfs_obj$stops <- some_stops
   
   gtfs_obj$.$dates_services <- gtfs_obj$.$dates_services[which(gtfs_obj$.$dates_services$service_id %in% service_ids),]
   if(feed_contains(gtfs_obj, "calendar")) {

--- a/R/filters.R
+++ b/R/filters.R
@@ -3,6 +3,7 @@
 #' @param gtfs_obj gtfs feed (tidygtfs object)
 #' @param service_ids the service for which to get stops 
 #' @param route_ids the route_ids for which to get stops 
+#' @param include_parent_stations whether to include stops refered in the parent_station column or not
 #' @return stops table for a given service or route
 #' 
 #' @importFrom dplyr filter
@@ -16,7 +17,7 @@
 #' select_route_id <- sample_n(nyc$routes, 1) %>% pull(route_id)
 #' filtered_stops_df <- filter_stops(nyc, select_service_id, select_route_id)
 #' }
-filter_stops <- function(gtfs_obj, service_ids, route_ids) {
+filter_stops <- function(gtfs_obj, service_ids, route_ids, include_parent_stations = TRUE) {
   service_id <- route_id <- stop_id <- trip_id <- NULL
   some_trips <- filter(gtfs_obj$trips, 
                        service_id %in% service_ids &
@@ -27,6 +28,16 @@ filter_stops <- function(gtfs_obj, service_ids, route_ids) {
   
   some_stops <- filter(gtfs_obj$stops,
                        stop_id %in% some_stop_times$stop_id)
+  if(include_parent_stations) {
+    some_stops <- some_stops |> 
+      bind_rows(
+        gtfs$stops |> 
+          filter(
+            stop_id %in% some_stops$parent_station 
+            & !(stop_id %in% some_stops$stop_id)
+          )
+      )
+  }
   
   return(some_stops)
 }
@@ -38,11 +49,12 @@ filter_stops <- function(gtfs_obj, service_ids, route_ids) {
 #' 
 #' @param gtfs_obj gtfs feed (tidygtfs object)
 #' @param trip_ids vector with trip_ids
+#' @param include_parent_stations whether to include stops refered in the parent_station column or not
 #' @return tidygtfs object with filtered tables
 #' 
 #' @seealso [filter_feed_by_date()], [filter_feed_by_area()], [filter_feed_by_stops()]
 #' @export
-filter_feed_by_trips = function(gtfs_obj, trip_ids) {
+filter_feed_by_trips = function(gtfs_obj, trip_ids, include_parent_stations = TRUE) {
   route_ids = gtfs_obj$trips[which(gtfs_obj$trips$trip_id %in% trip_ids),]
   route_ids <- unique(route_ids$route_id)
   
@@ -54,7 +66,11 @@ filter_feed_by_trips = function(gtfs_obj, trip_ids) {
   # other
   trip_stop_ids = gtfs_obj$stop_times$stop_id
   service_ids = unique(gtfs_obj$trips$service_id)
-  gtfs_obj$stops <- gtfs_obj$stops[which(gtfs_obj$stops$stop_id %in% trip_stop_ids),]
+  some_stops <- gtfs_obj$stops[which(gtfs_obj$stops$stop_id %in% trip_stop_ids),]
+  if (include_parent_stations) {
+    some_stops <- some_stops |> bind_rows(gtfs_obj$stops |> filter(stop_id %in% some_stops$parent_station & !(stop_id %in% some_stops$stop_id)))
+  }
+  gtfs_obj $ stops <- some_stops
   
   gtfs_obj$.$dates_services <- gtfs_obj$.$dates_services[which(gtfs_obj$.$dates_services$service_id %in% service_ids),]
   if(feed_contains(gtfs_obj, "calendar")) {
@@ -85,10 +101,11 @@ filter_feed_by_trips = function(gtfs_obj, trip_ids) {
 #' @param gtfs_obj gtfs feed (tidygtfs object)
 #' @param area all trips passing through this area are kept. Either a bounding box 
 #'             (numeric vector with xmin, ymin, xmax, ymax) or a sf object.
+#' @param include_parent_stations whether to include stops refered in the parent_station column or not
 #' @seealso [filter_feed_by_date()], [filter_feed_by_stops()], [filter_feed_by_trips()]
 #' @importFrom sf st_crs st_set_agr st_intersection st_geometry st_transform st_bbox
 #' @export
-filter_feed_by_area <- function(gtfs_obj, area) {
+filter_feed_by_area <- function(gtfs_obj, area, include_parent_stations = TRUE) {
   if(inherits(gtfs_obj$stops, "sf") && inherits(area, "sf")) {
     if(st_crs(gtfs_obj$stops) != st_crs(area)) {
       stop("feed and area are not in the same coordinate reference system")
@@ -111,7 +128,7 @@ filter_feed_by_area <- function(gtfs_obj, area) {
     stop_ids <- unique(stop_ids$stop_id)
   }
   
-  filter_feed_by_stops(gtfs_obj, stop_ids)
+  filter_feed_by_stops(gtfs_obj, stop_ids, include_parent_stations)
 }
 
 #' Filter a gtfs feed so that it only contains trips that pass the given stops
@@ -125,10 +142,11 @@ filter_feed_by_area <- function(gtfs_obj, area) {
 #' @param gtfs_obj gtfs feed (tidygtfs object)
 #' @param stop_ids vector with stop_ids. You can either provide stop_ids or stop_names 
 #' @param stop_names vector with stop_names (will be converted to stop_ids)
+#' @param include_parent_stations whether to include stops refered in the parent_station column or not
 #' 
 #' @seealso [filter_feed_by_date()], [filter_feed_by_area()], [filter_feed_by_trips()]
 #' @export
-filter_feed_by_stops = function(gtfs_obj, stop_ids = NULL, stop_names = NULL) {
+filter_feed_by_stops = function(gtfs_obj, stop_ids = NULL, stop_names = NULL, include_parent_stations = TRUE) {
   if(inherits(stop_ids, "sf")) {
     stop("Please use filter_feed_by_area with sf objects")
   }
@@ -144,7 +162,7 @@ filter_feed_by_stops = function(gtfs_obj, stop_ids = NULL, stop_names = NULL) {
 
   trip_ids = gtfs_obj$stop_times[which(gtfs_obj$stop_times$stop_id %in% stop_ids),]
   trip_ids <- unique(trip_ids$trip_id)
-  filter_feed_by_trips(gtfs_obj, trip_ids)
+  filter_feed_by_trips(gtfs_obj, trip_ids, include_parent_stations)
 }
 
 #' Filter a gtfs feed so that it only contains trips running on a given date
@@ -158,7 +176,7 @@ filter_feed_by_stops = function(gtfs_obj, stop_ids = NULL, stop_names = NULL) {
 #' @importFrom dplyr as_tibble
 #' @export
 filter_feed_by_date = function(gtfs_obj, extract_date,
-                               min_departure_time, max_arrival_time) {
+                               min_departure_time, max_arrival_time, include_parent_stations = TRUE) {
   st = filter_stop_times(gtfs_obj, extract_date, min_departure_time, max_arrival_time)
   st <- as_tibble(st)
   attributes(st)$stops <- NULL
@@ -169,7 +187,7 @@ filter_feed_by_date = function(gtfs_obj, extract_date,
 
   trip_ids <- unique(gtfs_obj$stop_times$trip_id)
   gtfs_obj$.$dates_services <- filter(gtfs_obj$.$dates_services, date == extract_date)
-  filter_feed_by_trips(gtfs_obj, trip_ids)
+  filter_feed_by_trips(gtfs_obj, trip_ids, include_parent_stations)
 }
 
 

--- a/R/filters.R
+++ b/R/filters.R
@@ -17,7 +17,7 @@
 #' select_route_id <- sample_n(nyc$routes, 1) %>% pull(route_id)
 #' filtered_stops_df <- filter_stops(nyc, select_service_id, select_route_id)
 #' }
-filter_stops <- function(gtfs_obj, service_ids, route_ids, include_parent_stations = TRUE) {
+filter_stops <- function(gtfs_obj, service_ids, route_ids, include_parent_stations = FALSE) {
   service_id <- route_id <- stop_id <- trip_id <- NULL
   some_trips <- filter(gtfs_obj$trips, 
                        service_id %in% service_ids &
@@ -54,7 +54,7 @@ filter_stops <- function(gtfs_obj, service_ids, route_ids, include_parent_statio
 #' 
 #' @seealso [filter_feed_by_date()], [filter_feed_by_area()], [filter_feed_by_stops()]
 #' @export
-filter_feed_by_trips = function(gtfs_obj, trip_ids, include_parent_stations = TRUE) {
+filter_feed_by_trips = function(gtfs_obj, trip_ids, include_parent_stations = FALSE) {
   route_ids = gtfs_obj$trips[which(gtfs_obj$trips$trip_id %in% trip_ids),]
   route_ids <- unique(route_ids$route_id)
   
@@ -105,7 +105,7 @@ filter_feed_by_trips = function(gtfs_obj, trip_ids, include_parent_stations = TR
 #' @seealso [filter_feed_by_date()], [filter_feed_by_stops()], [filter_feed_by_trips()]
 #' @importFrom sf st_crs st_set_agr st_intersection st_geometry st_transform st_bbox
 #' @export
-filter_feed_by_area <- function(gtfs_obj, area, include_parent_stations = TRUE) {
+filter_feed_by_area <- function(gtfs_obj, area, include_parent_stations = FALSE) {
   if(inherits(gtfs_obj$stops, "sf") && inherits(area, "sf")) {
     if(st_crs(gtfs_obj$stops) != st_crs(area)) {
       stop("feed and area are not in the same coordinate reference system")
@@ -146,7 +146,7 @@ filter_feed_by_area <- function(gtfs_obj, area, include_parent_stations = TRUE) 
 #' 
 #' @seealso [filter_feed_by_date()], [filter_feed_by_area()], [filter_feed_by_trips()]
 #' @export
-filter_feed_by_stops = function(gtfs_obj, stop_ids = NULL, stop_names = NULL, include_parent_stations = TRUE) {
+filter_feed_by_stops = function(gtfs_obj, stop_ids = NULL, stop_names = NULL, include_parent_stations = FALSE) {
   if(inherits(stop_ids, "sf")) {
     stop("Please use filter_feed_by_area with sf objects")
   }
@@ -176,7 +176,7 @@ filter_feed_by_stops = function(gtfs_obj, stop_ids = NULL, stop_names = NULL, in
 #' @importFrom dplyr as_tibble
 #' @export
 filter_feed_by_date = function(gtfs_obj, extract_date,
-                               min_departure_time, max_arrival_time, include_parent_stations = TRUE) {
+                               min_departure_time, max_arrival_time, include_parent_stations = FALSE) {
   st = filter_stop_times(gtfs_obj, extract_date, min_departure_time, max_arrival_time)
   st <- as_tibble(st)
   attributes(st)$stops <- NULL

--- a/man/filter_feed_by_area.Rd
+++ b/man/filter_feed_by_area.Rd
@@ -4,13 +4,15 @@
 \alias{filter_feed_by_area}
 \title{Filter a gtfs feed so that it only contains trips that pass a given area}
 \usage{
-filter_feed_by_area(gtfs_obj, area)
+filter_feed_by_area(gtfs_obj, area, include_parent_stations = TRUE)
 }
 \arguments{
 \item{gtfs_obj}{gtfs feed (tidygtfs object)}
 
 \item{area}{all trips passing through this area are kept. Either a bounding box
 (numeric vector with xmin, ymin, xmax, ymax) or a sf object.}
+
+\item{include_parent_stations}{whether to include stops refered in the parent_station column or not}
 }
 \value{
 tidygtfs object with filtered tables

--- a/man/filter_feed_by_area.Rd
+++ b/man/filter_feed_by_area.Rd
@@ -4,7 +4,7 @@
 \alias{filter_feed_by_area}
 \title{Filter a gtfs feed so that it only contains trips that pass a given area}
 \usage{
-filter_feed_by_area(gtfs_obj, area, include_parent_stations = TRUE)
+filter_feed_by_area(gtfs_obj, area, include_parent_stations = FALSE)
 }
 \arguments{
 \item{gtfs_obj}{gtfs feed (tidygtfs object)}

--- a/man/filter_feed_by_date.Rd
+++ b/man/filter_feed_by_date.Rd
@@ -8,7 +8,8 @@ filter_feed_by_date(
   gtfs_obj,
   extract_date,
   min_departure_time,
-  max_arrival_time
+  max_arrival_time,
+  include_parent_stations = TRUE
 )
 }
 \arguments{

--- a/man/filter_feed_by_date.Rd
+++ b/man/filter_feed_by_date.Rd
@@ -9,7 +9,7 @@ filter_feed_by_date(
   extract_date,
   min_departure_time,
   max_arrival_time,
-  include_parent_stations = TRUE
+  include_parent_stations = FALSE
 )
 }
 \arguments{

--- a/man/filter_feed_by_date.Rd
+++ b/man/filter_feed_by_date.Rd
@@ -22,6 +22,8 @@ hms object or numeric value in seconds.}
 
 \item{max_arrival_time}{(optional) The latest arrival time. Can be given as "HH:MM:SS",
 hms object or numeric value in seconds.}
+
+\item{include_parent_stations}{whether to include stops refered in the parent_station column or not}
 }
 \value{
 tidygtfs object with filtered tables

--- a/man/filter_feed_by_stops.Rd
+++ b/man/filter_feed_by_stops.Rd
@@ -8,7 +8,7 @@ filter_feed_by_stops(
   gtfs_obj,
   stop_ids = NULL,
   stop_names = NULL,
-  include_parent_stations = TRUE
+  include_parent_stations = FALSE
 )
 }
 \arguments{

--- a/man/filter_feed_by_stops.Rd
+++ b/man/filter_feed_by_stops.Rd
@@ -4,7 +4,12 @@
 \alias{filter_feed_by_stops}
 \title{Filter a gtfs feed so that it only contains trips that pass the given stops}
 \usage{
-filter_feed_by_stops(gtfs_obj, stop_ids = NULL, stop_names = NULL)
+filter_feed_by_stops(
+  gtfs_obj,
+  stop_ids = NULL,
+  stop_names = NULL,
+  include_parent_stations = TRUE
+)
 }
 \arguments{
 \item{gtfs_obj}{gtfs feed (tidygtfs object)}
@@ -12,6 +17,8 @@ filter_feed_by_stops(gtfs_obj, stop_ids = NULL, stop_names = NULL)
 \item{stop_ids}{vector with stop_ids. You can either provide stop_ids or stop_names}
 
 \item{stop_names}{vector with stop_names (will be converted to stop_ids)}
+
+\item{include_parent_stations}{whether to include stops refered in the parent_station column or not}
 }
 \value{
 tidygtfs object with filtered tables

--- a/man/filter_feed_by_trips.Rd
+++ b/man/filter_feed_by_trips.Rd
@@ -4,7 +4,7 @@
 \alias{filter_feed_by_trips}
 \title{Filter a gtfs feed so that it only contains a given set of trips}
 \usage{
-filter_feed_by_trips(gtfs_obj, trip_ids, include_parent_stations = TRUE)
+filter_feed_by_trips(gtfs_obj, trip_ids, include_parent_stations = FALSE)
 }
 \arguments{
 \item{gtfs_obj}{gtfs feed (tidygtfs object)}

--- a/man/filter_feed_by_trips.Rd
+++ b/man/filter_feed_by_trips.Rd
@@ -4,12 +4,14 @@
 \alias{filter_feed_by_trips}
 \title{Filter a gtfs feed so that it only contains a given set of trips}
 \usage{
-filter_feed_by_trips(gtfs_obj, trip_ids)
+filter_feed_by_trips(gtfs_obj, trip_ids, include_parent_stations = TRUE)
 }
 \arguments{
 \item{gtfs_obj}{gtfs feed (tidygtfs object)}
 
 \item{trip_ids}{vector with trip_ids}
+
+\item{include_parent_stations}{whether to include stops refered in the parent_station column or not}
 }
 \value{
 tidygtfs object with filtered tables

--- a/man/filter_stops.Rd
+++ b/man/filter_stops.Rd
@@ -4,7 +4,7 @@
 \alias{filter_stops}
 \title{Get a set of stops for a given set of service ids and route ids}
 \usage{
-filter_stops(gtfs_obj, service_ids, route_ids, include_parent_stations = TRUE)
+filter_stops(gtfs_obj, service_ids, route_ids, include_parent_stations = FALSE)
 }
 \arguments{
 \item{gtfs_obj}{gtfs feed (tidygtfs object)}

--- a/man/filter_stops.Rd
+++ b/man/filter_stops.Rd
@@ -4,7 +4,7 @@
 \alias{filter_stops}
 \title{Get a set of stops for a given set of service ids and route ids}
 \usage{
-filter_stops(gtfs_obj, service_ids, route_ids)
+filter_stops(gtfs_obj, service_ids, route_ids, include_parent_stations = TRUE)
 }
 \arguments{
 \item{gtfs_obj}{gtfs feed (tidygtfs object)}
@@ -12,6 +12,8 @@ filter_stops(gtfs_obj, service_ids, route_ids)
 \item{service_ids}{the service for which to get stops}
 
 \item{route_ids}{the route_ids for which to get stops}
+
+\item{include_parent_stations}{whether to include stops refered in the parent_station column or not}
 }
 \value{
 stops table for a given service or route

--- a/man/gtfs_duke.Rd
+++ b/man/gtfs_duke.Rd
@@ -8,7 +8,7 @@
 An object of class \code{tidygtfs} (inherits from \code{gtfs}) of length 18.
 }
 \usage{
-gtfs_duke
+data(gtfs_duke)
 }
 \description{
 Data obtained from

--- a/man/json_to_sf.Rd
+++ b/man/json_to_sf.Rd
@@ -13,6 +13,6 @@ json_to_sf(json_list)
 sf object
 }
 \description{
-The json object is written to a temporary file and re-read with \code{\link[sf:st_read]{sf::read_sf()}}.
+The json object is written to a temporary file and re-read with \code{\link[sf:read_sf]{sf::read_sf()}}.
 }
 \keyword{internal}

--- a/man/route_type_names.Rd
+++ b/man/route_type_names.Rd
@@ -15,7 +15,7 @@ A data frame with 136 rows and 2 variables:
 \url{https://gist.github.com/derhuerst/b0243339e22c310bee2386388151e11e}
 }
 \usage{
-route_type_names
+data(route_type_names)
 }
 \description{
 Extended GTFS Route Types: https://developers.google.com/transit/gtfs/reference/extended-route-types

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -200,6 +200,19 @@ test_that("stops cluster", {
   expect_s3_class(g_nyc2, "tidygtfs")
 })
 
+test_that("stops cluster test include_parent_stations", {
+  skip_on_cran()
+  
+  g_nyc = read_gtfs(system.file("extdata", "nyc_subway.zip", package = "tidytransit"))
+  g_nyc2_no_parent <- filter_feed_by_area(g_nyc, c(-74.0144, 40.7402, -73.9581, 40.7696), include_parent_stations = FALSE)
+  expect_true("101N" %in% g_nyc2_no_parent$stops$stop_id)
+  expect_false("101" %in% g_nyc2_no_parent$stops$stop_id)
+
+  g_nyc2_with_parent <- filter_feed_by_area(g_nyc, c(-74.0144, 40.7402, -73.9581, 40.7696), include_parent_stations = TRUE)
+  expect_true("101N" %in% g_nyc2_with_parent$stops$stop_id)
+  expect_true("101" %in% g_nyc2_with_parent$stops$stop_id)
+})
+
 test_that("handle feeds with geojson",{
   locations_path = system.file("extdata", "locations_feed.zip", package = "tidytransit")
   gtfsio_tmpdir = tempfile("gtfsio")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -30,6 +30,18 @@ test_that("filter_stops", {
   expect_equal(nrow(fs2), 0)
 })
 
+test_that("filter_stops_include_parent_stations", {
+  g = read_gtfs(system.file("extdata", "routing.zip", package = "tidytransit"))
+
+  fs1_no_parent = filter_stops(g, service_ids = "WEEK", route_ids = c("lineA", "lineD"), include_parent_stations = FALSE)
+  expect_true("stop1a" %in% fs1_no_parent$stop_id)
+  expect_false("stop1" %in% fs1_no_parent$stop_id)
+
+  fs1_with_parent = filter_stops(g, service_ids = "WEEK", route_ids = c("lineA", "lineD"), include_parent_stations = TRUE)
+  expect_true("stop1a" %in% fs1_with_parent$stop_id)
+  expect_true("stop1" %in% fs1_with_parent$stop_id)
+})
+
 test_that("filter_feed_by_stops", {
   g = read_gtfs(system.file("extdata", "routing.zip", package = "tidytransit"))
   g_sf = gtfs_as_sf(g)
@@ -50,6 +62,18 @@ test_that("filter_feed_by_stops", {
   expect_error(filter_feed_by_stops(g, "xyz"), "stop_ids found in stops table: xyz")
   expect_error(filter_feed_by_stops(g, "xyz", "XYZ"), "Please provide either stop_ids or stop_names")
   expect_error(filter_feed_by_stops(g), "Please provide either stop_ids or stop_names")
+})
+
+test_that("filter_feed_by_stops_include_parent_stations", {
+  g = read_gtfs(system.file("extdata", "routing.zip", package = "tidytransit"))
+  
+  f1_no_parent = filter_feed_by_stops(g, stop_ids = c("stop1a"), include_parent_stations = FALSE)
+  expect_true("stop1a" %in% f1_no_parent$stops$stop_id)
+  expect_false("stop1" %in% f1_no_parent$stops$stop_id)
+  
+  f1_with_parent = filter_feed_by_stops(g, stop_ids = c("stop1a"), include_parent_stations = TRUE)
+  expect_true("stop1a" %in% f1_with_parent$stops$stop_id)
+  expect_true("stop1" %in% f1_with_parent$stops$stop_id)
 })
 
 test_that("filter_feed with shapes", {
@@ -93,6 +117,20 @@ test_that("filter_feed_by_date", {
   expect_s3_class(g2$stop_times, "tbl_df")
 })
 
+test_that("filter_feed_by_date_include_parent_stations", {
+  skip_on_cran()
+  g0 = read_gtfs(system.file("extdata", "nyc_subway.zip",
+                             package = "tidytransit"))
+  
+  f1_no_parent = filter_feed_by_date(g0, "2018-06-28", include_parent_stations = FALSE)
+  expect_true("101N" %in% f1_no_parent$stops$stop_id)
+  expect_false("101" %in% f1_no_parent$stops$stop_id)
+  
+  f1_with_parent = filter_feed_by_date(g0, "2018-06-28", include_parent_stations = TRUE)
+  expect_true("101N" %in% f1_with_parent$stops$stop_id)
+  expect_true("101" %in% f1_with_parent$stops$stop_id)
+})
+
 test_that("feed_contains, feed_has_non_empty_table", {
   g = gtfs_duke
   expect_false(feed_contains(g, "dates_services"))
@@ -111,3 +149,24 @@ test_that("feed_contains, feed_has_non_empty_table", {
   g <- set_servicepattern(g)
   expect_true(feed_contains.(g, "servicepatterns"))
 })
+
+test_that("filter_feed_by_trips", {
+  g = read_gtfs(system.file("extdata", "routing.zip", package = "tidytransit"))
+  some_trips = c("routeA1", "routeD1")
+  f1 = filter_feed_by_trips(g, some_trips)
+  expect_equal(sort(unique(f1$trips$trip_id)), sort(some_trips))
+})
+
+test_that("filter_feed_by_trips_include_parent_stations", {
+  g = read_gtfs(system.file("extdata", "routing.zip", package = "tidytransit"))
+  some_trips = c("routeA1")
+  f1_no_transfers = filter_feed_by_trips(g, some_trips, include_parent_stations = FALSE)
+  expect_true("stop1a" %in% f1_no_transfers$stops$stop_id)
+  expect_false("stop1" %in% f1_no_transfers$stops$stop_id)
+
+  f1_transfers = filter_feed_by_trips(g, some_trips, include_parent_stations = TRUE)
+  expect_true("stop1a" %in% f1_transfers$stops$stop_id)
+  expect_true("stop1" %in% f1_transfers$stops$stop_id)
+})
+
+


### PR DESCRIPTION
When filtering a GTFS feed using any of `tidytransit` methods, the stops that are `parent_station` are removed from the results if they are not at `stop_times` table of the filtered trips. However, they are still relevant in the scope of the filtered result. I suggest adding a parameter `include_parent_stations` in the filtering methods parameter to avoid this error (which I think should be `TRUE` as default), while still enabling the users to set it to `FALSE` and disregard these stations.

``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

gtfs <- tidytransit::read_gtfs("https://backend.tcbarreiro.pt/download-gtfs")
summary(gtfs)
#> tidygtfs object
#> files        agency, routes, stop_times, trips, shapes, dead_runs, layover, blocks, calendar, calendar_dates, feed_info, stops
#> agency       Transportes Colectivos do Barreiro
#> service      from 2026-05-06 to 2026-12-31
#> uses         stop_times (no frequencies)
#> # routes       76
#> # trips      3239
#> # stop_ids    279
#> # stop_names  162
#> # shapes       76
gtfs$stops |> filter(stop_id=="000000" | parent_station=="000000") |> select(stop_id, stop_name, parent_station)
#> # A tibble: 10 × 3
#>    stop_id stop_name                               parent_station
#>    <chr>   <chr>                                   <chr>         
#>  1 000000  Terminal Rodo-Ferro-Fluvial do Barreiro <NA>          
#>  2 000001  Terminal - Carreira 1                   000000        
#>  3 000170  Terminal - Carreira 14                  000000        
#>  4 000180  Terminal - Carreira 15                  000000        
#>  5 000187  Terminal - Carreira 16                  000000        
#>  6 000027  Terminal - Carreira 2                   000000        
#>  7 000053  Terminal - Carreira 3                   000000        
#>  8 000113  Terminal - Carreira 7                   000000        
#>  9 000077  Terminal - Carreira 4                   000000        
#> 10 000127  Terminal - Carreira 8                   000000

gtfs_day <- tidytransit::filter_feed_by_date(gtfs, "2026-06-01")
#> Warning in filter_stop_times(gtfs_obj, extract_date, min_departure_time, : No
#> transfers found in feed, travel_times() or raptor() might produce unexpected
#> results
gtfs_day$stops |> filter(stop_id=="000000" | parent_station=="000000") |> select(stop_id, stop_name, parent_station)
#> # A tibble: 9 × 3
#>   stop_id stop_name              parent_station
#>   <chr>   <chr>                  <chr>         
#> 1 000001  Terminal - Carreira 1  000000        
#> 2 000170  Terminal - Carreira 14 000000        
#> 3 000180  Terminal - Carreira 15 000000        
#> 4 000187  Terminal - Carreira 16 000000        
#> 5 000027  Terminal - Carreira 2  000000        
#> 6 000053  Terminal - Carreira 3  000000        
#> 7 000113  Terminal - Carreira 7  000000        
#> 8 000077  Terminal - Carreira 4  000000        
#> 9 000127  Terminal - Carreira 8  000000
```

<sup>Created on 2026-06-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
